### PR TITLE
Modified model so initialized unit is preserved with Quantity

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Versions {
-  val Squants = "0.5.1-SNAPSHOT"
+  val Squants = "0.5.2-SNAPSHOT"
   val Scala = "2.11.1"
   val ScalaCross = Seq("2.11.1", "2.10.4")
 

--- a/src/main/scala/squants/Dimensionless.scala
+++ b/src/main/scala/squants/Dimensionless.scala
@@ -21,11 +21,12 @@ import squants.time.{ Hertz, Frequency, TimeIntegral }
  *
  * @param value Double the amount
  */
-final class Dimensionless private (val value: Double)
+final class Dimensionless private (val value: Double, val unit: DimensionlessUnit)
     extends Quantity[Dimensionless]
     with TimeIntegral[Frequency] {
 
-  def valueUnit = Dimensionless.valueUnit
+  def dimension = Dimensionless
+
   protected def timeDerived = Hertz(toEach)
   protected[squants] def time = Seconds(1)
 
@@ -41,11 +42,12 @@ final class Dimensionless private (val value: Double)
 /**
  * Factory singleton for [[squants.Dimensionless]]
  */
-object Dimensionless extends QuantityCompanion[Dimensionless] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = new Dimensionless(num.toDouble(n))
+object Dimensionless extends Dimension[Dimensionless] {
+  def apply[A](n: A, unit: DimensionlessUnit)(implicit num: Numeric[A]) = new Dimensionless(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Dimensionless"
-  def valueUnit = Each
+  def primaryUnit = Each
+  def siUnit = Each
   def units = Set(Each, Dozen, Score, Gross)
 }
 
@@ -55,13 +57,13 @@ object Dimensionless extends QuantityCompanion[Dimensionless] {
  * The DimensionlessUnit is a useful paradox
  */
 trait DimensionlessUnit extends UnitOfMeasure[Dimensionless] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Dimensionless(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Dimensionless(n, this)
 }
 
 /**
  * Represents a unit of singles
  */
-object Each extends DimensionlessUnit with ValueUnit {
+object Each extends DimensionlessUnit with PrimaryUnit with SiUnit {
   val symbol = "ea"
 }
 
@@ -111,7 +113,7 @@ object DimensionlessConversions {
     def million = Each(num.toDouble(n) * 1000000D)
   }
 
-  implicit object DimensionlessNumeric extends AbstractQuantityNumeric[Dimensionless](Dimensionless.valueUnit) {
+  implicit object DimensionlessNumeric extends AbstractQuantityNumeric[Dimensionless](Dimensionless.primaryUnit) {
     /**
      * Dimensionless quantities support the times operation.
      * This method overrides the default [[squants.AbstractQuantityNumeric.times]] which thrown an exception

--- a/src/main/scala/squants/UnitOfMeasure.scala
+++ b/src/main/scala/squants/UnitOfMeasure.scala
@@ -75,7 +75,7 @@ trait UnitOfMeasure[A <: Quantity[A]] extends Serializable {
 trait UnitConverter { uom: UnitOfMeasure[_] ⇒
 
   /**
-   * Defines a multiplier value relative to the Quantity's [[squants.ValueUnit]]
+   * Defines a multiplier value relative to the Quantity's [[squants.PrimaryUnit]]
    *
    * @return
    */
@@ -95,11 +95,13 @@ trait UnitConverter { uom: UnitOfMeasure[_] ⇒
 }
 
 /**
- * Identifies the Unit of Measure used for storing the quantity's underlying value
+ * Identifies the Unit of Measure with a conversionFactor of 1.0.
+ *
+ * It is used as the intermediary unit during conversions
  *
  * Each Quantity should have one and only one ValueUnit
  */
-trait ValueUnit extends UnitConverter { uom: UnitOfMeasure[_] ⇒
+trait PrimaryUnit extends UnitConverter { uom: UnitOfMeasure[_] ⇒
 
   /**
    * Implements the converterTo method to just return the underlying value
@@ -120,6 +122,11 @@ trait ValueUnit extends UnitConverter { uom: UnitOfMeasure[_] ⇒
 }
 
 /**
+ * A market trait identifying SI Units
+ */
+trait SiUnit
+
+/**
  * A marker trait identifying SI Base Units
  */
-trait BaseUnit { uom: UnitOfMeasure[_] ⇒ }
+trait SiBaseUnit extends SiUnit

--- a/src/main/scala/squants/Vector.scala
+++ b/src/main/scala/squants/Vector.scala
@@ -148,7 +148,7 @@ case class DoubleVector(coordinates: Double*) extends Vector[Double] {
  * @tparam A QuantityType
  */
 case class QuantityVector[A <: Quantity[A]](coordinates: A*) extends Vector[A] {
-  def valueUnit = coordinates(0).valueUnit
+  def valueUnit = coordinates(0).unit
   def magnitude: A = valueUnit(math.sqrt(coordinates.toTraversable.map(v ⇒ v.to(valueUnit) * v.to(valueUnit)).sum))
   def normalize: Vector[A] = this / magnitude.to(valueUnit)
 
@@ -222,7 +222,7 @@ case class QuantityVector[A <: Quantity[A]](coordinates: A*) extends Vector[A] {
   def /[B <: Quantity[B], C <: Quantity[C]](that: B)(implicit mapTo: (A, B) ⇒ C) = divide(that)
 
   def dotProduct[B <: Quantity[B], C <: Quantity[C]](that: Vector[B])(implicit mapTo: (A, B) ⇒ C, num: Numeric[C]): C =
-    coordinates.toIterable.zipAll(that.coordinates.toIterable, valueUnit(0), that.coordinates(0).valueUnit(0)).toTraversable.map(v ⇒ mapTo(v._1, v._2)).sum
+    coordinates.toIterable.zipAll(that.coordinates.toIterable, valueUnit(0), that.coordinates(0).unit(0)).toTraversable.map(v ⇒ mapTo(v._1, v._2)).sum
 }
 
 /**

--- a/src/main/scala/squants/electro/Capacitance.scala
+++ b/src/main/scala/squants/electro/Capacitance.scala
@@ -16,10 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.Farads]]
  */
-final class Capacitance private (val value: Double)
+final class Capacitance private (val value: Double, val unit: CapacitanceUnit)
     extends Quantity[Capacitance] {
 
-  def valueUnit = Capacitance.valueUnit
+  def dimension = Capacitance
 
   def *(that: ElectricPotential): ElectricCharge = Coulombs(this.toFarads * that.toVolts)
   def /(that: Length) = ??? // returns Permittivity
@@ -32,19 +32,20 @@ final class Capacitance private (val value: Double)
   def toKilofarads = to(Kilofarads)
 }
 
-object Capacitance extends QuantityCompanion[Capacitance] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new Capacitance(num.toDouble(n))
+object Capacitance extends Dimension[Capacitance] {
+  private[electro] def apply[A](n: A, unit: CapacitanceUnit)(implicit num: Numeric[A]) = new Capacitance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Capacitance"
-  def valueUnit = Farads
+  def primaryUnit = Farads
+  def siUnit = Farads
   def units = Set(Farads, Picofarads, Nanofarads, Microfarads, Millifarads, Kilofarads)
 }
 
 trait CapacitanceUnit extends UnitOfMeasure[Capacitance] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Capacitance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Capacitance(n, this)
 }
 
-object Farads extends CapacitanceUnit with ValueUnit {
+object Farads extends CapacitanceUnit with PrimaryUnit with SiUnit {
   val symbol = "F"
 }
 
@@ -90,5 +91,5 @@ object CapacitanceConversions {
     def kilofarads = Kilofarads(n)
   }
 
-  implicit object CapacitanceNumeric extends AbstractQuantityNumeric[Capacitance](Capacitance.valueUnit)
+  implicit object CapacitanceNumeric extends AbstractQuantityNumeric[Capacitance](Capacitance.primaryUnit)
 }

--- a/src/main/scala/squants/electro/Conductivity.scala
+++ b/src/main/scala/squants/electro/Conductivity.scala
@@ -17,9 +17,10 @@ import squants.space.Length
  *
  * @param value value in [[squants.electro.SiemensPerMeter]]
  */
-final class Conductivity private (val value: Double) extends Quantity[Conductivity] {
+final class Conductivity private (val value: Double, val unit: ConductivityUnit)
+    extends Quantity[Conductivity] {
 
-  def valueUnit = Conductivity.valueUnit
+  def dimension = Conductivity
 
   def *(that: Length): ElectricalConductance = Siemens(toSiemensPerMeter * that.toMeters)
 
@@ -27,19 +28,20 @@ final class Conductivity private (val value: Double) extends Quantity[Conductivi
   def inOhmMeters = OhmMeters(1d / toSiemensPerMeter)
 }
 
-object Conductivity extends QuantityCompanion[Conductivity] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new Conductivity(num.toDouble(n))
+object Conductivity extends Dimension[Conductivity] {
+  private[electro] def apply[A](n: A, unit: ConductivityUnit)(implicit num: Numeric[A]) = new Conductivity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Conductivity"
-  def valueUnit = SiemensPerMeter
+  def primaryUnit = SiemensPerMeter
+  def siUnit = SiemensPerMeter
   def units = Set(SiemensPerMeter)
 }
 
 trait ConductivityUnit extends UnitOfMeasure[Conductivity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Conductivity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Conductivity(n, this)
 }
 
-object SiemensPerMeter extends ConductivityUnit with ValueUnit {
+object SiemensPerMeter extends ConductivityUnit with PrimaryUnit with SiUnit {
   val symbol = "S/m"
 }
 
@@ -50,5 +52,5 @@ object ConductivityConversions {
     def siemensPerMeter = SiemensPerMeter(n)
   }
 
-  implicit object ConductivityNumeric extends AbstractQuantityNumeric[Conductivity](Conductivity.valueUnit)
+  implicit object ConductivityNumeric extends AbstractQuantityNumeric[Conductivity](Conductivity.primaryUnit)
 }

--- a/src/main/scala/squants/electro/ElectricCharge.scala
+++ b/src/main/scala/squants/electro/ElectricCharge.scala
@@ -19,11 +19,12 @@ import squants.Time
  *
  * @param value value in [[squants.electro.Coulombs]]
  */
-final class ElectricCharge private (val value: Double)
+final class ElectricCharge private (val value: Double, val unit: ElectricChargeUnit)
     extends Quantity[ElectricCharge]
     with TimeIntegral[ElectricCurrent] {
 
-  def valueUnit = ElectricCharge.valueUnit
+  def dimension = ElectricCharge
+
   protected def timeDerived = Amperes(toCoulombs)
   protected def time = Seconds(1)
 
@@ -46,20 +47,21 @@ final class ElectricCharge private (val value: Double)
   def toMilliampereSeconds = to(MilliampereSeconds)
 }
 
-object ElectricCharge extends QuantityCompanion[ElectricCharge] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new ElectricCharge(num.toDouble(n))
+object ElectricCharge extends Dimension[ElectricCharge] {
+  private[electro] def apply[A](n: A, unit: ElectricChargeUnit)(implicit num: Numeric[A]) = new ElectricCharge(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ElectricCharge"
-  def valueUnit = Coulombs
+  def primaryUnit = Coulombs
+  def siUnit = Coulombs
   def units = Set(Coulombs, Picocoulombs, Nanocoulombs, Microcoulombs, Millicoulombs, Abcoulombs,
     AmpereHours, MilliampereHours, MilliampereSeconds)
 }
 
 trait ElectricChargeUnit extends UnitOfMeasure[ElectricCharge] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricCharge(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricCharge(n, this)
 }
 
-object Coulombs extends ElectricChargeUnit with ValueUnit {
+object Coulombs extends ElectricChargeUnit with PrimaryUnit with SiUnit {
   val symbol = "C"
 }
 
@@ -127,5 +129,5 @@ object ElectricChargeConversions {
   }
 
   implicit object ElectricalChargeNumeric
-    extends AbstractQuantityNumeric[ElectricCharge](ElectricCharge.valueUnit)
+    extends AbstractQuantityNumeric[ElectricCharge](ElectricCharge.primaryUnit)
 }

--- a/src/main/scala/squants/electro/ElectricCurrent.scala
+++ b/src/main/scala/squants/electro/ElectricCurrent.scala
@@ -20,10 +20,11 @@ import squants.energy.Watts
  *
  * @param value the amount of charge in [[squants.electro.Amperes]]'s
  */
-final class ElectricCurrent private (val value: Double) extends Quantity[ElectricCurrent]
+final class ElectricCurrent private (val value: Double, val unit: ElectricCurrentUnit)
+    extends Quantity[ElectricCurrent]
     with TimeDerivative[ElectricCharge] {
 
-  def valueUnit = ElectricCurrent.valueUnit
+  def dimension = ElectricCurrent
 
   protected def timeIntegrated = Coulombs(toAmperes)
   protected[squants] def time = Seconds(1)
@@ -39,27 +40,27 @@ final class ElectricCurrent private (val value: Double) extends Quantity[Electri
   def toMilliamperes = to(Milliamperes)
 }
 
-object ElectricCurrent extends QuantityCompanion[ElectricCurrent] with BaseQuantity {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new ElectricCurrent(num.toDouble(n))
+object ElectricCurrent extends Dimension[ElectricCurrent] with BaseDimension {
+  private[electro] def apply[A](n: A, unit: ElectricCurrentUnit)(implicit num: Numeric[A]) = new ElectricCurrent(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ElectricCurrent"
-  def valueUnit = Amperes
+  def primaryUnit = Amperes
+  def siUnit = Amperes
   def units = Set(Amperes, Milliamperes)
   def dimensionSymbol = "I"
-  def baseUnit = Amperes
 }
 
 /**
  * Base trait for units of [[squants.electro.ElectricCurrent]]
  */
 trait ElectricCurrentUnit extends UnitOfMeasure[ElectricCurrent] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricCurrent(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricCurrent(n, this)
 }
 
 /**
  * Amperes
  */
-object Amperes extends ElectricCurrentUnit with ValueUnit with BaseUnit {
+object Amperes extends ElectricCurrentUnit with PrimaryUnit with SiBaseUnit {
   val symbol = "A"
 }
 
@@ -87,5 +88,5 @@ object ElectricCurrentConversions {
   }
 
   implicit object ElectricCurrentNumeric
-    extends AbstractQuantityNumeric[ElectricCurrent](ElectricCurrent.valueUnit)
+    extends AbstractQuantityNumeric[ElectricCurrent](ElectricCurrent.primaryUnit)
 }

--- a/src/main/scala/squants/electro/ElectricPotential.scala
+++ b/src/main/scala/squants/electro/ElectricPotential.scala
@@ -18,10 +18,12 @@ import squants.time.{ Seconds, TimeDerivative }
  *
  * @param value value in [[squants.electro.Volts]]
  */
-final class ElectricPotential private (val value: Double) extends Quantity[ElectricPotential]
+final class ElectricPotential private (val value: Double, val unit: ElectricPotentialUnit)
+    extends Quantity[ElectricPotential]
     with TimeDerivative[MagneticFlux] {
 
-  def valueUnit = ElectricPotential.valueUnit
+  def dimension = ElectricPotential
+
   protected def timeIntegrated = Webers(toVolts)
   protected[squants] def time = Seconds(1)
 
@@ -40,19 +42,20 @@ final class ElectricPotential private (val value: Double) extends Quantity[Elect
   def toMegavolts = to(Megavolts)
 }
 
-object ElectricPotential extends QuantityCompanion[ElectricPotential] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new ElectricPotential(num.toDouble(n))
+object ElectricPotential extends Dimension[ElectricPotential] {
+  private[electro] def apply[A](n: A, unit: ElectricPotentialUnit)(implicit num: Numeric[A]) = new ElectricPotential(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ElectricPotential"
-  def valueUnit = Volts
+  def primaryUnit = Volts
+  def siUnit = Volts
   def units = Set(Volts, Microvolts, Millivolts, Kilovolts, Megavolts)
 }
 
 trait ElectricPotentialUnit extends UnitOfMeasure[ElectricPotential] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricPotential(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricPotential(n, this)
 }
 
-object Volts extends ElectricPotentialUnit with ValueUnit {
+object Volts extends ElectricPotentialUnit with PrimaryUnit with SiUnit {
   val symbol = "V"
 }
 
@@ -92,6 +95,6 @@ object ElectricPotentialConversions {
     def megavolts = Megavolts(n)
   }
 
-  implicit object ElectricPotentialNumeric extends AbstractQuantityNumeric[ElectricPotential](ElectricPotential.valueUnit)
+  implicit object ElectricPotentialNumeric extends AbstractQuantityNumeric[ElectricPotential](ElectricPotential.primaryUnit)
 }
 

--- a/src/main/scala/squants/electro/ElectricalConductance.scala
+++ b/src/main/scala/squants/electro/ElectricalConductance.scala
@@ -16,10 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.Siemens]]
  */
-final class ElectricalConductance private (val value: Double)
+final class ElectricalConductance private (val value: Double, val unit: ElectricalConductanceUnit)
     extends Quantity[ElectricalConductance] {
 
-  def valueUnit = ElectricalConductance.valueUnit
+  def dimension = ElectricalConductance
 
   def /(that: Length): Conductivity = SiemensPerMeter(toSiemens / that.toMeters)
   def /(that: Conductivity): Length = Meters(toSiemens / that.toSiemensPerMeter)
@@ -29,19 +29,20 @@ final class ElectricalConductance private (val value: Double)
   def inOhms = Ohms(1.0 / value)
 }
 
-object ElectricalConductance extends QuantityCompanion[ElectricalConductance] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new ElectricalConductance(num.toDouble(n))
+object ElectricalConductance extends Dimension[ElectricalConductance] {
+  private[electro] def apply[A](n: A, unit: ElectricalConductanceUnit)(implicit num: Numeric[A]) = new ElectricalConductance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ElectricalConductance"
-  def valueUnit = Siemens
+  def primaryUnit = Siemens
+  def siUnit = Siemens
   def units = Set(Siemens)
 }
 
 trait ElectricalConductanceUnit extends UnitOfMeasure[ElectricalConductance] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricalConductance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricalConductance(n, this)
 }
 
-object Siemens extends ElectricalConductanceUnit with ValueUnit {
+object Siemens extends ElectricalConductanceUnit with PrimaryUnit with SiUnit {
   val symbol = "S"
 }
 
@@ -52,5 +53,5 @@ object ElectricalConductanceConversions {
     def siemens = Siemens(n)
   }
 
-  implicit object ElectricalConductanceNumeric extends AbstractQuantityNumeric[ElectricalConductance](ElectricalConductance.valueUnit)
+  implicit object ElectricalConductanceNumeric extends AbstractQuantityNumeric[ElectricalConductance](ElectricalConductance.primaryUnit)
 }

--- a/src/main/scala/squants/electro/ElectricalResistance.scala
+++ b/src/main/scala/squants/electro/ElectricalResistance.scala
@@ -16,10 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.Ohms]]
  */
-final class ElectricalResistance private (val value: Double)
+final class ElectricalResistance private (val value: Double, val unit: ElectricalResistanceUnit)
     extends Quantity[ElectricalResistance] {
 
-  def valueUnit = ElectricalResistance.valueUnit
+  def dimension = ElectricalResistance
 
   def *(that: ElectricCurrent): ElectricPotential = Volts(toOhms * that.toAmperes)
   def *(that: Length): Resistivity = OhmMeters(toOhms * that.toMeters)
@@ -35,19 +35,20 @@ final class ElectricalResistance private (val value: Double)
   def inSiemens = Siemens(1.0 / to(Ohms))
 }
 
-object ElectricalResistance extends QuantityCompanion[ElectricalResistance] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new ElectricalResistance(num.toDouble(n))
+object ElectricalResistance extends Dimension[ElectricalResistance] {
+  private[electro] def apply[A](n: A, unit: ElectricalResistanceUnit)(implicit num: Numeric[A]) = new ElectricalResistance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ElectricalResistance"
-  def valueUnit = Ohms
+  def primaryUnit = Ohms
+  def siUnit = Ohms
   def units = Set(Ohms, Nanohms, Microohms, Milliohms, Kilohms, Megohms, Gigohms)
 }
 
 trait ElectricalResistanceUnit extends UnitOfMeasure[ElectricalResistance] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricalResistance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ElectricalResistance(n, this)
 }
 
-object Ohms extends ElectricalResistanceUnit with ValueUnit {
+object Ohms extends ElectricalResistanceUnit with PrimaryUnit with SiUnit {
   val symbol = "Ω"
 }
 
@@ -101,5 +102,5 @@ object ElectricalResistanceConversions {
   }
 
   implicit object ElectricalResistanceNumeric
-    extends AbstractQuantityNumeric[ElectricalResistance](ElectricalResistance.valueUnit)
+    extends AbstractQuantityNumeric[ElectricalResistance](ElectricalResistance.primaryUnit)
 }

--- a/src/main/scala/squants/electro/Inductance.scala
+++ b/src/main/scala/squants/electro/Inductance.scala
@@ -16,9 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.Henry]]
  */
-final class Inductance private (val value: Double) extends Quantity[Inductance] {
+final class Inductance private (val value: Double, val unit: InductanceUnit)
+    extends Quantity[Inductance] {
 
-  def valueUnit = Inductance.valueUnit
+  def dimension = Inductance
 
   def *(that: ElectricCurrent): MagneticFlux = Webers(toHenry * that.toAmperes)
   def /(that: Length) = ??? // returns Permeability
@@ -26,19 +27,21 @@ final class Inductance private (val value: Double) extends Quantity[Inductance] 
   def toHenry = to(Henry)
 }
 
-object Inductance extends QuantityCompanion[Inductance] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new Inductance(num.toDouble(n))
+object Inductance extends Dimension[Inductance] {
+  private[electro] def apply[A](n: A, unit: InductanceUnit)(implicit num: Numeric[A]) = new Inductance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Inductance"
-  def valueUnit = Henry
+  def primaryUnit = Henry
+  def siUnit = Henry
   def units = Set(Henry)
 }
 
-trait InductanceUnit extends UnitOfMeasure[Inductance] with UnitConverter
+trait InductanceUnit extends UnitOfMeasure[Inductance] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = Inductance(n, this)
+}
 
-object Henry extends InductanceUnit with ValueUnit {
+object Henry extends InductanceUnit with PrimaryUnit with SiUnit {
   val symbol = "H"
-  def apply[A](n: A)(implicit num: Numeric[A]) = Inductance(n)
 }
 
 object InductanceConversions {
@@ -48,5 +51,5 @@ object InductanceConversions {
     def henry = Henry(n)
   }
 
-  implicit object InductanceNumeric extends AbstractQuantityNumeric[Inductance](Inductance.valueUnit)
+  implicit object InductanceNumeric extends AbstractQuantityNumeric[Inductance](Inductance.primaryUnit)
 }

--- a/src/main/scala/squants/electro/MagneticFlux.scala
+++ b/src/main/scala/squants/electro/MagneticFlux.scala
@@ -18,10 +18,12 @@ import squants.space.SquareMeters
  *
  * @param value value in [[squants.electro.Webers]]
  */
-final class MagneticFlux private (val value: Double) extends Quantity[MagneticFlux]
+final class MagneticFlux private (val value: Double, val unit: MagneticFluxUnit)
+    extends Quantity[MagneticFlux]
     with TimeIntegral[ElectricPotential] {
 
-  def valueUnit = MagneticFlux.valueUnit
+  def dimension = MagneticFlux
+
   protected def timeDerived = Volts(toWebers)
   protected def time = Seconds(1)
 
@@ -33,19 +35,21 @@ final class MagneticFlux private (val value: Double) extends Quantity[MagneticFl
   def toWebers = to(Webers)
 }
 
-object MagneticFlux extends QuantityCompanion[MagneticFlux] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new MagneticFlux(num.toDouble(n))
+object MagneticFlux extends Dimension[MagneticFlux] {
+  private[electro] def apply[A](n: A, unit: MagneticFluxUnit)(implicit num: Numeric[A]) = new MagneticFlux(num.toDouble(n), unit)
   def apply = parseString _
   def name = "MagneticFlux"
-  def valueUnit = Webers
+  def primaryUnit = Webers
+  def siUnit = Webers
   def units = Set(Webers)
 }
 
-trait MagneticFluxUnit extends UnitOfMeasure[MagneticFlux] with UnitConverter
+trait MagneticFluxUnit extends UnitOfMeasure[MagneticFlux] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = MagneticFlux(n, this)
+}
 
-object Webers extends MagneticFluxUnit with ValueUnit {
+object Webers extends MagneticFluxUnit with PrimaryUnit with SiUnit {
   val symbol = "Wb"
-  def apply[A](n: A)(implicit num: Numeric[A]) = MagneticFlux(n)
 }
 
 object MagneticFluxConversions {
@@ -55,5 +59,5 @@ object MagneticFluxConversions {
     def webers = Webers(n)
   }
 
-  implicit object MagneticFluxNumeric extends AbstractQuantityNumeric[MagneticFlux](MagneticFlux.valueUnit)
+  implicit object MagneticFluxNumeric extends AbstractQuantityNumeric[MagneticFlux](MagneticFlux.primaryUnit)
 }

--- a/src/main/scala/squants/electro/MagneticFluxDensity.scala
+++ b/src/main/scala/squants/electro/MagneticFluxDensity.scala
@@ -16,9 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.Teslas]]
  */
-final class MagneticFluxDensity private (val value: Double) extends Quantity[MagneticFluxDensity] {
+final class MagneticFluxDensity private (val value: Double, val unit: MagneticFluxDensityUnit)
+    extends Quantity[MagneticFluxDensity] {
 
-  def valueUnit = MagneticFluxDensity.valueUnit
+  def dimension = MagneticFluxDensity
 
   def *(that: Area): MagneticFlux = Webers(toTeslas * that.toSquareMeters)
 
@@ -26,19 +27,20 @@ final class MagneticFluxDensity private (val value: Double) extends Quantity[Mag
   def toGuass = to(Gauss)
 }
 
-object MagneticFluxDensity extends QuantityCompanion[MagneticFluxDensity] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new MagneticFluxDensity(num.toDouble(n))
+object MagneticFluxDensity extends Dimension[MagneticFluxDensity] {
+  private[electro] def apply[A](n: A, unit: MagneticFluxDensityUnit)(implicit num: Numeric[A]) = new MagneticFluxDensity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "MagneticFluxDensity"
-  def valueUnit = Teslas
+  def primaryUnit = Teslas
+  def siUnit = Teslas
   def units = Set(Teslas, Gauss)
 }
 
 trait MagneticFluxDensityUnit extends UnitOfMeasure[MagneticFluxDensity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = MagneticFluxDensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = MagneticFluxDensity(n, this)
 }
 
-object Teslas extends MagneticFluxDensityUnit with ValueUnit {
+object Teslas extends MagneticFluxDensityUnit with PrimaryUnit with SiUnit {
   val symbol = "T"
 }
 
@@ -56,5 +58,5 @@ object MagneticFluxDensityConversions {
     def gauss = Gauss(n)
   }
 
-  implicit object MagneticFluxDensistyNumeric extends AbstractQuantityNumeric[MagneticFluxDensity](MagneticFluxDensity.valueUnit)
+  implicit object MagneticFluxDensistyNumeric extends AbstractQuantityNumeric[MagneticFluxDensity](MagneticFluxDensity.primaryUnit)
 }

--- a/src/main/scala/squants/electro/Resistivity.scala
+++ b/src/main/scala/squants/electro/Resistivity.scala
@@ -16,9 +16,10 @@ import squants._
  *
  * @param value value in [[squants.electro.OhmMeters]]
  */
-final class Resistivity private (val value: Double) extends Quantity[Resistivity] {
+final class Resistivity private (val value: Double, val unit: ResistivityUnit)
+    extends Quantity[Resistivity] {
 
-  def valueUnit = Resistivity.valueUnit
+  def dimension = Resistivity
 
   def /(that: Length): ElectricalResistance = Ohms(toOhmMeters / that.toMeters)
   def /(that: ElectricalResistance): Length = Meters(toOhmMeters / that.toOhms)
@@ -27,19 +28,20 @@ final class Resistivity private (val value: Double) extends Quantity[Resistivity
   def inSiemensPerMeter = SiemensPerMeter(1d / toOhmMeters)
 }
 
-object Resistivity extends QuantityCompanion[Resistivity] {
-  private[electro] def apply[A](n: A)(implicit num: Numeric[A]) = new Resistivity(num.toDouble(n))
+object Resistivity extends Dimension[Resistivity] {
+  private[electro] def apply[A](n: A, unit: ResistivityUnit)(implicit num: Numeric[A]) = new Resistivity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Resistivity"
-  def valueUnit = OhmMeters
+  def primaryUnit = OhmMeters
+  def siUnit = OhmMeters
   def units = Set(OhmMeters)
 }
 
-trait ResitivityUnit extends UnitOfMeasure[Resistivity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Resistivity(convertFrom(n))
+trait ResistivityUnit extends UnitOfMeasure[Resistivity] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = Resistivity(n, this)
 }
 
-object OhmMeters extends ResitivityUnit with ValueUnit {
+object OhmMeters extends ResistivityUnit with PrimaryUnit with SiUnit {
   def symbol = "Ω⋅m"
 }
 
@@ -50,5 +52,5 @@ object ResistivityConversions {
     def ohmMeters = OhmMeters(n)
   }
 
-  implicit object ResistivityNumeric extends AbstractQuantityNumeric[Resistivity](Resistivity.valueUnit)
+  implicit object ResistivityNumeric extends AbstractQuantityNumeric[Resistivity](Resistivity.primaryUnit)
 }

--- a/src/main/scala/squants/energy/EnergyDensity.scala
+++ b/src/main/scala/squants/energy/EnergyDensity.scala
@@ -18,28 +18,30 @@ import squants._
  *
  * @param value value in [[squants.energy.WattHours]]
  */
-final class EnergyDensity private (val value: Double) extends Quantity[EnergyDensity] {
+final class EnergyDensity private (val value: Double, val unit: EnergyDensityUnit)
+    extends Quantity[EnergyDensity] {
 
-  def valueUnit = EnergyDensity.valueUnit
+  def dimension = EnergyDensity
 
   def *(that: Volume): Energy = Joules(toJoulesPerCubicMeter * that.toCubicMeters)
 
   def toJoulesPerCubicMeter = to(JoulesPerCubicMeter)
 }
 
-object EnergyDensity extends QuantityCompanion[EnergyDensity] {
-  private[energy] def apply[A](n: A)(implicit num: Numeric[A]) = new EnergyDensity(num.toDouble(n))
+object EnergyDensity extends Dimension[EnergyDensity] {
+  private[energy] def apply[A](n: A, unit: EnergyDensityUnit)(implicit num: Numeric[A]) = new EnergyDensity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "EnergyDensity"
-  def valueUnit = JoulesPerCubicMeter
+  def primaryUnit = JoulesPerCubicMeter
+  def siUnit = JoulesPerCubicMeter
   def units = Set(JoulesPerCubicMeter)
 }
 
 trait EnergyDensityUnit extends UnitOfMeasure[EnergyDensity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = EnergyDensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = EnergyDensity(n, this)
 }
 
-object JoulesPerCubicMeter extends EnergyDensityUnit with ValueUnit {
+object JoulesPerCubicMeter extends EnergyDensityUnit with PrimaryUnit with SiUnit {
   val symbol = "j/m³"
 }
 
@@ -50,5 +52,5 @@ object EnergyDensityConversions {
     def joulesPerCubicMeter = JoulesPerCubicMeter(n)
   }
 
-  implicit object EnergyDensityNumeric extends AbstractQuantityNumeric[EnergyDensity](EnergyDensity.valueUnit)
+  implicit object EnergyDensityNumeric extends AbstractQuantityNumeric[EnergyDensity](EnergyDensity.primaryUnit)
 }

--- a/src/main/scala/squants/energy/PowerRamp.scala
+++ b/src/main/scala/squants/energy/PowerRamp.scala
@@ -20,12 +20,13 @@ import squants.Time
  *
  * @param value value in [[squants.energy.WattsPerHour]]
  */
-final class PowerRamp private (val value: Double)
+final class PowerRamp private (val value: Double, val unit: PowerRampUnit)
     extends Quantity[PowerRamp]
     with TimeDerivative[Power]
     with SecondTimeDerivative[Energy] {
 
-  def valueUnit = PowerRamp.valueUnit
+  def dimension = PowerRamp
+
   protected def timeIntegrated = Watts(toWattsPerHour)
   protected[squants] def time = Hours(1)
 
@@ -37,29 +38,23 @@ final class PowerRamp private (val value: Double)
   def toKilowattsPerMinute = to(KilowattsPerMinute)
   def toMegawattsPerHour = to(MegawattsPerHour)
   def toGigawattsPerHour = to(GigawattsPerHour)
-
-  override def toString = toString(this match {
-    case GigawattsPerHour(gwh) if gwh > 1.0 ⇒ GigawattsPerHour
-    case MegawattsPerHour(mwh) if mwh > 1.0 ⇒ MegawattsPerHour
-    case KilowattsPerHour(kwh) if kwh > 1.0 ⇒ KilowattsPerHour
-    case _                                  ⇒ WattsPerHour
-  })
 }
 
-object PowerRamp extends QuantityCompanion[PowerRamp] {
-  private[energy] def apply[A](n: A)(implicit num: Numeric[A]) = new PowerRamp(num.toDouble(n))
-  def apply(change: Power, time: Time): PowerRamp = apply(change.toWatts / time.toHours)
+object PowerRamp extends Dimension[PowerRamp] {
+  private[energy] def apply[A](n: A, unit: PowerRampUnit)(implicit num: Numeric[A]) = new PowerRamp(num.toDouble(n), unit)
+  def apply(change: Power, time: Time): PowerRamp = apply(change.toWatts / time.toHours, WattsPerHour)
   def apply = parseString _
   def name = "PowerRamp"
-  def valueUnit = WattsPerHour
+  def primaryUnit = WattsPerHour
+  def siUnit = WattsPerHour
   def units = Set(WattsPerHour, WattsPerMinute, KilowattsPerHour, KilowattsPerMinute, MegawattsPerHour, GigawattsPerHour)
 }
 
 trait PowerRampUnit extends UnitOfMeasure[PowerRamp] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = PowerRamp(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = PowerRamp(n, this)
 }
 
-object WattsPerHour extends PowerRampUnit with ValueUnit {
+object WattsPerHour extends PowerRampUnit with PrimaryUnit with SiUnit {
   val symbol = "W/h"
 }
 
@@ -115,5 +110,5 @@ object PowerRampConversions {
     def toPowerRamp = PowerRamp(s)
   }
 
-  implicit object PowerRampNumeric extends AbstractQuantityNumeric[PowerRamp](PowerRamp.valueUnit)
+  implicit object PowerRampNumeric extends AbstractQuantityNumeric[PowerRamp](PowerRamp.primaryUnit)
 }

--- a/src/main/scala/squants/energy/SpecificEnergy.scala
+++ b/src/main/scala/squants/energy/SpecificEnergy.scala
@@ -16,9 +16,9 @@ import squants._
  *
  * @param value value in [[squants.energy.Grays]]
  */
-final class SpecificEnergy private (val value: Double) extends Quantity[SpecificEnergy] {
+final class SpecificEnergy private (val value: Double, val unit: SpecificEnergyUnit) extends Quantity[SpecificEnergy] {
 
-  def valueUnit = SpecificEnergy.valueUnit
+  def dimension = SpecificEnergy
 
   def *(that: Mass): Energy = Joules(toGrays * that.toKilograms)
   def /(that: Time) = ??? // returns AbsorbedEnergyRate
@@ -26,19 +26,20 @@ final class SpecificEnergy private (val value: Double) extends Quantity[Specific
   def toGrays = to(Grays)
 }
 
-object SpecificEnergy extends QuantityCompanion[SpecificEnergy] {
-  private[energy] def apply[A](n: A)(implicit num: Numeric[A]) = new SpecificEnergy(num.toDouble(n))
+object SpecificEnergy extends Dimension[SpecificEnergy] {
+  private[energy] def apply[A](n: A, unit: SpecificEnergyUnit)(implicit num: Numeric[A]) = new SpecificEnergy(num.toDouble(n), unit)
   def apply = parseString _
   def name = "SpecificEnergy"
-  def valueUnit = Grays
+  def primaryUnit = Grays
+  def siUnit = Grays
   def units = Set(Grays)
 }
 
 trait SpecificEnergyUnit extends UnitOfMeasure[SpecificEnergy] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = SpecificEnergy(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = SpecificEnergy(n, this)
 }
 
-object Grays extends SpecificEnergyUnit with ValueUnit {
+object Grays extends SpecificEnergyUnit with PrimaryUnit with SiUnit {
   val symbol = "Gy"
 }
 
@@ -49,6 +50,6 @@ object SpecificEnergyConversions {
     def grays = Grays(n)
   }
 
-  implicit object SpecificEnergyNumeric extends AbstractQuantityNumeric[SpecificEnergy](SpecificEnergy.valueUnit)
+  implicit object SpecificEnergyNumeric extends AbstractQuantityNumeric[SpecificEnergy](SpecificEnergy.primaryUnit)
 }
 

--- a/src/main/scala/squants/market/Money.scala
+++ b/src/main/scala/squants/market/Money.scala
@@ -41,7 +41,9 @@ import scala.util.{ Failure, Success, Try }
 final class Money private (val amount: BigDecimal)(val currency: Currency)
     extends Quantity[Money] {
 
-  def valueUnit = currency
+  def dimension = Money
+
+  def unit = currency
   def value = amount.toDouble
 
   /**
@@ -325,7 +327,7 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
 /**
  * Factory singleton for Money
  */
-object Money {
+object Money extends Dimension[Money] {
   def apply(value: Double)(implicit fxContext: MoneyContext) = new Money(BigDecimal(value))(fxContext.defaultCurrency)
   def apply(value: BigDecimal)(implicit fxContext: MoneyContext) = new Money(value)(fxContext.defaultCurrency)
 
@@ -342,6 +344,11 @@ object Money {
       case _                      ⇒ Failure(QuantityStringParseException("Unable to parse Money", s))
     }
   }
+  def name = "Money"
+
+  def primaryUnit = ??? // Should not be used with Money - drawn from MoneyContext instead
+  def siUnit = ??? // Should not be used with Money - drawn from MoneyContext instead
+  def units = ??? // Should not be used with Money - drawn from MoneyContext instead
 }
 
 /**

--- a/src/main/scala/squants/mass/AreaDensity.scala
+++ b/src/main/scala/squants/mass/AreaDensity.scala
@@ -16,9 +16,10 @@ import squants._
  *
  * @param value Double
  */
-final class AreaDensity private (val value: Double) extends Quantity[AreaDensity] {
+final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
+    extends Quantity[AreaDensity] {
 
-  def valueUnit = AreaDensity.valueUnit
+  def dimension = AreaDensity
 
   def *(that: Area): Mass = Kilograms(value * that.toSquareMeters)
 
@@ -28,20 +29,21 @@ final class AreaDensity private (val value: Double) extends Quantity[AreaDensity
 /**
  * Factory singleton for [[squants.mass.AreaDensity]] values
  */
-object AreaDensity extends QuantityCompanion[AreaDensity] {
-  private[mass] def apply[A](n: A)(implicit num: Numeric[A]) = new AreaDensity(num.toDouble(n))
+object AreaDensity extends Dimension[AreaDensity] {
+  private[mass] def apply[A](n: A, unit: AreaDensityUnit)(implicit num: Numeric[A]) = new AreaDensity(num.toDouble(n), unit)
   def apply(mass: Mass, area: Area): AreaDensity = KilogramsPerSquareMeter(mass.toKilograms / area.toSquareMeters)
   def apply = parseString _
   def name = "AreaDensity"
-  def valueUnit = KilogramsPerSquareMeter
+  def primaryUnit = KilogramsPerSquareMeter
+  def siUnit = KilogramsPerSquareMeter
   def units = Set(KilogramsPerSquareMeter)
 }
 
 trait AreaDensityUnit extends UnitOfMeasure[AreaDensity] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = AreaDensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = AreaDensity(n, this)
 }
 
-object KilogramsPerSquareMeter extends AreaDensityUnit with ValueUnit {
+object KilogramsPerSquareMeter extends AreaDensityUnit with PrimaryUnit with SiUnit {
   val symbol = "kg/m²"
 }
 
@@ -52,5 +54,5 @@ object AreaDensityConversions {
     def kilogramsPerSquareMeter = KilogramsPerSquareMeter(n)
   }
 
-  implicit object AreaDensityNumeric extends AbstractQuantityNumeric[AreaDensity](AreaDensity.valueUnit)
+  implicit object AreaDensityNumeric extends AbstractQuantityNumeric[AreaDensity](AreaDensity.primaryUnit)
 }

--- a/src/main/scala/squants/mass/ChemicalAmount.scala
+++ b/src/main/scala/squants/mass/ChemicalAmount.scala
@@ -16,9 +16,10 @@ import squants._
  *
  * @param value in [[squants.mass.Moles]]
  */
-final class ChemicalAmount private (val value: Double) extends Quantity[ChemicalAmount] {
+final class ChemicalAmount private (val value: Double, val unit: ChemicalAmountUnit)
+    extends Quantity[ChemicalAmount] {
 
-  def valueUnit = ChemicalAmount.valueUnit
+  def dimension = ChemicalAmount
 
   def /(that: Volume) = ??? // returns SubstanceConcentration
 
@@ -26,21 +27,21 @@ final class ChemicalAmount private (val value: Double) extends Quantity[Chemical
   def toPoundMoles = to(PoundMoles)
 }
 
-object ChemicalAmount extends QuantityCompanion[ChemicalAmount] with BaseQuantity {
-  private[mass] def apply[A](n: A)(implicit num: Numeric[A]) = new ChemicalAmount(num.toDouble(n))
+object ChemicalAmount extends Dimension[ChemicalAmount] with BaseDimension {
+  private[mass] def apply[A](n: A, unit: ChemicalAmountUnit)(implicit num: Numeric[A]) = new ChemicalAmount(num.toDouble(n), unit)
   def apply = parseString _
   val name = "ChemicalAmount"
-  def valueUnit = Moles
+  def primaryUnit = Moles
+  def siUnit = Moles
   def units = Set(Moles, PoundMoles)
   def dimensionSymbol = "N"
-  def baseUnit = Moles
 }
 
 trait ChemicalAmountUnit extends UnitOfMeasure[ChemicalAmount] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ChemicalAmount(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ChemicalAmount(n, this)
 }
 
-object Moles extends ChemicalAmountUnit with ValueUnit with BaseUnit {
+object Moles extends ChemicalAmountUnit with PrimaryUnit with SiBaseUnit {
   val symbol = "mol"
 }
 
@@ -58,5 +59,5 @@ object ChemicalAmountConversions {
     def poundMoles = PoundMoles(n)
   }
 
-  implicit object ChemicalAmountNumeric extends AbstractQuantityNumeric[ChemicalAmount](ChemicalAmount.valueUnit)
+  implicit object ChemicalAmountNumeric extends AbstractQuantityNumeric[ChemicalAmount](ChemicalAmount.primaryUnit)
 }

--- a/src/main/scala/squants/mass/Density.scala
+++ b/src/main/scala/squants/mass/Density.scala
@@ -16,29 +16,31 @@ import squants._
  *
  * @param value Double
  */
-case class Density(value: Double) extends Quantity[Density] {
+final class Density private (val value: Double, val unit: DensityUnit)
+    extends Quantity[Density] {
 
-  def valueUnit = KilogramsPerCubicMeter
+  def dimension = Density
 
   def *(that: Volume): Mass = Kilograms(value * that.toCubicMeters)
 
   def toKilogramsPerCubicMeter = to(KilogramsPerCubicMeter)
 }
 
-object Density extends QuantityCompanion[Density] {
-  private[mass] def apply[A](n: A)(implicit num: Numeric[A]) = new Density(num.toDouble(n))
+object Density extends Dimension[Density] {
+  private[mass] def apply[A](n: A, unit: DensityUnit)(implicit num: Numeric[A]) = new Density(num.toDouble(n), unit)
   def apply(m: Mass, v: Volume): Density = KilogramsPerCubicMeter(m.toKilograms / v.toCubicMeters)
   def apply = parseString _
   def name = "Density"
-  def valueUnit = KilogramsPerCubicMeter
+  def primaryUnit = KilogramsPerCubicMeter
+  def siUnit = KilogramsPerCubicMeter
   def units = Set(KilogramsPerCubicMeter)
 }
 
-trait DensityUnit extends UnitOfMeasure[Density] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Density(convertFrom(n))
+trait DensityUnit extends UnitOfMeasure[Density] with UnitConverter with SiUnit {
+  def apply[A](n: A)(implicit num: Numeric[A]) = Density(n, this)
 }
 
-object KilogramsPerCubicMeter extends DensityUnit with ValueUnit {
+object KilogramsPerCubicMeter extends DensityUnit with PrimaryUnit {
   val symbol = "kg/m³"
 }
 

--- a/src/main/scala/squants/mass/Mass.scala
+++ b/src/main/scala/squants/mass/Mass.scala
@@ -9,10 +9,10 @@
 package squants.mass
 
 import scala.language.implicitConversions
-import squants._
+import squants.{ Energy ⇒ _, _ }
 import squants.time.TimeIntegral
 import squants.motion._
-import squants.energy.{ SpecificEnergy, Joules }
+import squants.energy.{ SpecificEnergy, Energy, Joules }
 import squants.space.{ SquareMeters, CubicMeters }
 import squants.motion.Force
 import squants.Velocity
@@ -28,10 +28,12 @@ import squants.motion.Momentum
  *
  * @param value the value in the [[squants.mass.Grams]]
  */
-final class Mass private (val value: Double) extends Quantity[Mass]
+final class Mass private (val value: Double, val unit: MassUnit)
+    extends Quantity[Mass]
     with TimeIntegral[MassFlowRate] {
 
-  def valueUnit = Mass.valueUnit
+  def dimension = Mass
+
   protected def timeDerived = KilogramsPerSecond(toKilograms)
   protected def time = Seconds(1)
 
@@ -50,36 +52,29 @@ final class Mass private (val value: Double) extends Quantity[Mass]
   def toTonnes = to(Tonnes)
   def toPounds = to(Pounds)
   def toOunces = to(Ounces)
-
-  override def toString = toString(this match {
-    case Tonnes(t) if t >= 1.0      ⇒ Tonnes
-    case Kilograms(kg) if kg >= 1.0 ⇒ Kilograms
-    case Grams(g) if g >= 1.0       ⇒ Grams
-    case _                          ⇒ Milligrams
-  })
 }
 
 /**
  * Factory singleton for [[squants.mass.Mass]] values
  */
-object Mass extends QuantityCompanion[Mass] with BaseQuantity {
-  private[mass] def apply[A](n: A)(implicit num: Numeric[A]) = new Mass(num.toDouble(n))
+object Mass extends Dimension[Mass] with BaseDimension {
+  private[mass] def apply[A](n: A, unit: MassUnit)(implicit num: Numeric[A]) = new Mass(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Mass"
-  def valueUnit = Grams
+  def primaryUnit = Grams
+  def siUnit = Kilograms
   def units = Set(Micrograms, Milligrams, Grams, Kilograms, Tonnes, Pounds, Ounces)
   def dimensionSymbol = "M"
-  def baseUnit = Kilograms
 }
 
 /**
  * Base trait for units of [[squants.mass.Mass]]
  */
 trait MassUnit extends UnitOfMeasure[Mass] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Mass(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Mass(n, this)
 }
 
-object Grams extends MassUnit with ValueUnit {
+object Grams extends MassUnit with PrimaryUnit {
   val symbol = "g"
 }
 
@@ -93,7 +88,7 @@ object Milligrams extends MassUnit {
   val symbol = "mg"
 }
 
-object Kilograms extends MassUnit with BaseUnit {
+object Kilograms extends MassUnit with SiBaseUnit {
   val conversionFactor = MetricSystem.Kilo
   val symbol = "kg"
 }
@@ -144,6 +139,6 @@ object MassConversions {
     def toMass = Mass(s)
   }
 
-  implicit object MassNumeric extends AbstractQuantityNumeric[Mass](Mass.valueUnit)
+  implicit object MassNumeric extends AbstractQuantityNumeric[Mass](Mass.primaryUnit)
 }
 

--- a/src/main/scala/squants/motion/Acceleration.scala
+++ b/src/main/scala/squants/motion/Acceleration.scala
@@ -22,13 +22,14 @@ import squants.space.{ UsMiles, Feet }
  *
  * @param value Double
  */
-final class Acceleration private (val value: Double)
+final class Acceleration private (val value: Double, val unit: AccelerationUnit)
     extends Quantity[Acceleration]
     with TimeDerivative[Velocity]
     with SecondTimeDerivative[Length]
     with TimeIntegral[Jerk] {
 
-  def valueUnit = Acceleration.valueUnit
+  def dimension = Acceleration
+
   protected def timeIntegrated = MetersPerSecond(toMetersPerSecondSquared)
   protected def timeDerived = MetersPerSecondCubed(toMetersPerSecondSquared)
   protected[squants] def time = Seconds(1)
@@ -43,11 +44,12 @@ final class Acceleration private (val value: Double)
   def toEarthGravities = to(EarthGravities)
 }
 
-object Acceleration extends QuantityCompanion[Acceleration] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Acceleration(num.toDouble(n))
+object Acceleration extends Dimension[Acceleration] {
+  private[motion] def apply[A](n: A, unit: AccelerationUnit)(implicit num: Numeric[A]) = new Acceleration(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Acceleration"
-  def valueUnit = MetersPerSecondSquared
+  def primaryUnit = MetersPerSecondSquared
+  def siUnit = MetersPerSecondSquared
   def units = Set(FeetPerSecondSquared, MetersPerSecondSquared, UsMilesPerHourSquared, EarthGravities)
 }
 
@@ -59,10 +61,10 @@ object Acceleration extends QuantityCompanion[Acceleration] {
  *
  */
 trait AccelerationUnit extends UnitOfMeasure[Acceleration] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Acceleration(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Acceleration(n, this)
 }
 
-object MetersPerSecondSquared extends AccelerationUnit with ValueUnit {
+object MetersPerSecondSquared extends AccelerationUnit with PrimaryUnit with SiUnit {
   val symbol = "m/s²"
 }
 
@@ -91,5 +93,5 @@ object AccelerationConversions {
     def fpss = FeetPerSecondSquared(n)
   }
 
-  implicit object AccelerationNumeric extends AbstractQuantityNumeric[Acceleration](Acceleration.valueUnit)
+  implicit object AccelerationNumeric extends AbstractQuantityNumeric[Acceleration](Acceleration.primaryUnit)
 }

--- a/src/main/scala/squants/motion/AngularVelocity.scala
+++ b/src/main/scala/squants/motion/AngularVelocity.scala
@@ -18,9 +18,10 @@ import squants.space.{ Turns, Gradians, Degrees }
  * @param value Double
  *
  */
-final class AngularVelocity private (val value: Double) extends Quantity[AngularVelocity] {
+final class AngularVelocity private (val value: Double, val unit: AngularVelocityUnit)
+    extends Quantity[AngularVelocity] {
   // TODO - Make this a TimeDerivative of Angle
-  def valueUnit = AngularVelocity.valueUnit
+  def dimension = AngularVelocity
 
   def toRadiansPerSecond = to(RadiansPerSecond)
   def toDegreesPerSecond = to(DegreesPerSecond)
@@ -28,19 +29,20 @@ final class AngularVelocity private (val value: Double) extends Quantity[Angular
   def toTurnsPerSecond = to(TurnsPerSecond)
 }
 
-object AngularVelocity extends QuantityCompanion[AngularVelocity] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new AngularVelocity(num.toDouble(n))
+object AngularVelocity extends Dimension[AngularVelocity] {
+  private[motion] def apply[A](n: A, unit: AngularVelocityUnit)(implicit num: Numeric[A]) = new AngularVelocity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "AngularVelocity"
-  def valueUnit = RadiansPerSecond
+  def primaryUnit = RadiansPerSecond
+  def siUnit = RadiansPerSecond
   def units = Set(RadiansPerSecond, DegreesPerSecond, GradsPerSecond, TurnsPerSecond)
 }
 
 trait AngularVelocityUnit extends UnitOfMeasure[AngularVelocity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = AngularVelocity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = AngularVelocity(n, this)
 }
 
-object RadiansPerSecond extends AngularVelocityUnit with ValueUnit {
+object RadiansPerSecond extends AngularVelocityUnit with PrimaryUnit with SiUnit {
   val symbol = "rad/s"
 }
 
@@ -72,5 +74,5 @@ object AngularVelocityConversions {
     def turnsPerSecond = TurnsPerSecond(n)
   }
 
-  implicit object AngularVelocityNumeric extends AbstractQuantityNumeric[AngularVelocity](AngularVelocity.valueUnit)
+  implicit object AngularVelocityNumeric extends AbstractQuantityNumeric[AngularVelocity](AngularVelocity.primaryUnit)
 }

--- a/src/main/scala/squants/motion/Force.scala
+++ b/src/main/scala/squants/motion/Force.scala
@@ -20,10 +20,12 @@ import squants.space.SquareMeters
  *
  * @param value Double
  */
-final class Force private (val value: Double) extends Quantity[Force]
+final class Force private (val value: Double, val unit: ForceUnit)
+    extends Quantity[Force]
     with TimeDerivative[Momentum] with TimeIntegral[Yank] {
 
-  def valueUnit = Force.valueUnit
+  def dimension = Force
+
   protected def timeIntegrated = NewtonSeconds(toNewtons)
   protected def timeDerived = NewtonsPerSecond(toNewtons)
   override def time = Seconds(1)
@@ -41,19 +43,20 @@ final class Force private (val value: Double) extends Quantity[Force]
   def toPoundForce = to(PoundForce)
 }
 
-object Force extends QuantityCompanion[Force] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Force(num.toDouble(n))
+object Force extends Dimension[Force] {
+  private[motion] def apply[A](n: A, unit: ForceUnit)(implicit num: Numeric[A]) = new Force(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Force"
-  def valueUnit = Newtons
+  def primaryUnit = Newtons
+  def siUnit = Newtons
   def units = Set(Newtons, KilogramForce, PoundForce)
 }
 
 trait ForceUnit extends UnitOfMeasure[Force] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Force(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Force(n, this)
 }
 
-object Newtons extends ForceUnit with ValueUnit {
+object Newtons extends ForceUnit with PrimaryUnit with SiUnit {
   val symbol = "N"
 }
 
@@ -79,6 +82,6 @@ object ForceConversions {
     def lbf = PoundForce(1)
   }
 
-  implicit object ForceNumeric extends AbstractQuantityNumeric[Force](Force.valueUnit)
+  implicit object ForceNumeric extends AbstractQuantityNumeric[Force](Force.primaryUnit)
 }
 

--- a/src/main/scala/squants/motion/Jerk.scala
+++ b/src/main/scala/squants/motion/Jerk.scala
@@ -20,12 +20,13 @@ import squants.space.Feet
  *
  * @param value Double
  */
-final class Jerk private (val value: Double)
+final class Jerk private (val value: Double, val unit: JerkUnit)
     extends Quantity[Jerk]
     with TimeDerivative[Acceleration]
     with SecondTimeDerivative[Velocity] {
 
-  def valueUnit = Jerk.valueUnit
+  def dimension = Jerk
+
   protected def timeIntegrated = MetersPerSecondSquared(toMetersPerSecondCubed)
   protected[squants] def time = Seconds(1)
 
@@ -35,19 +36,20 @@ final class Jerk private (val value: Double)
   def toFeetPerSecondCubed = to(FeetPerSecondCubed)
 }
 
-object Jerk extends QuantityCompanion[Jerk] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Jerk(num.toDouble(n))
+object Jerk extends Dimension[Jerk] {
+  private[motion] def apply[A](n: A, unit: JerkUnit)(implicit num: Numeric[A]) = new Jerk(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Jerk"
-  def valueUnit = MetersPerSecondCubed
+  def primaryUnit = MetersPerSecondCubed
+  def siUnit = MetersPerSecondCubed
   def units = Set(MetersPerSecondCubed, FeetPerSecondCubed)
 }
 
 trait JerkUnit extends UnitOfMeasure[Jerk] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Jerk(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Jerk(n, this)
 }
 
-object MetersPerSecondCubed extends JerkUnit with ValueUnit {
+object MetersPerSecondCubed extends JerkUnit with PrimaryUnit with SiUnit {
   val symbol = "m/s³"
 }
 object FeetPerSecondCubed extends JerkUnit {
@@ -64,5 +66,5 @@ object JerkConversions {
     def feetPerSecondCubed = FeetPerSecondCubed(n)
   }
 
-  implicit object JerkNumeric extends AbstractQuantityNumeric[Jerk](Jerk.valueUnit)
+  implicit object JerkNumeric extends AbstractQuantityNumeric[Jerk](Jerk.primaryUnit)
 }

--- a/src/main/scala/squants/motion/MassFlowRate.scala
+++ b/src/main/scala/squants/motion/MassFlowRate.scala
@@ -18,9 +18,12 @@ import squants._
  *
  * @param value Double
  */
-final class MassFlowRate private (val value: Double) extends Quantity[MassFlowRate] with TimeDerivative[Mass] {
+final class MassFlowRate private (val value: Double, val unit: MassFlowRateUnit)
+    extends Quantity[MassFlowRate]
+    with TimeDerivative[Mass] {
 
-  def valueUnit = MassFlowRate.valueUnit
+  def dimension = MassFlowRate
+
   protected def timeIntegrated = Kilograms(toKilogramsPerSecond)
   protected[squants] def time = Seconds(1)
 
@@ -29,19 +32,20 @@ final class MassFlowRate private (val value: Double) extends Quantity[MassFlowRa
   def toKilopoundsPerHour = to(KilopoundsPerHour)
 }
 
-object MassFlowRate extends QuantityCompanion[MassFlowRate] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new MassFlowRate(num.toDouble(n))
+object MassFlowRate extends Dimension[MassFlowRate] {
+  private[motion] def apply[A](n: A, unit: MassFlowRateUnit)(implicit num: Numeric[A]) = new MassFlowRate(num.toDouble(n), unit)
   def apply = parseString _
   def name = "MassFlowRate"
-  def valueUnit = KilogramsPerSecond
+  def primaryUnit = KilogramsPerSecond
+  def siUnit = KilogramsPerSecond
   def units = Set(KilogramsPerSecond, PoundsPerSecond, KilopoundsPerHour)
 }
 
 trait MassFlowRateUnit extends UnitOfMeasure[MassFlowRate] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = MassFlowRate(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = MassFlowRate(n, this)
 }
 
-object KilogramsPerSecond extends MassFlowRateUnit with ValueUnit {
+object KilogramsPerSecond extends MassFlowRateUnit with PrimaryUnit with SiUnit {
   val symbol = "kg/s"
 }
 
@@ -66,5 +70,5 @@ object MassFlowRateConversions {
     def kilopoundsPerHour = KilopoundsPerHour(n)
   }
 
-  implicit object MassFlowRateNumeric extends AbstractQuantityNumeric[MassFlowRate](MassFlowRate.valueUnit)
+  implicit object MassFlowRateNumeric extends AbstractQuantityNumeric[MassFlowRate](MassFlowRate.primaryUnit)
 }

--- a/src/main/scala/squants/motion/Momentum.scala
+++ b/src/main/scala/squants/motion/Momentum.scala
@@ -18,12 +18,13 @@ import squants.mass.Kilograms
  *
  * @param value Double
  */
-final class Momentum private (val value: Double)
+final class Momentum private (val value: Double, val unit: MomentumUnit)
     extends Quantity[Momentum]
     with TimeIntegral[Force]
     with SecondTimeIntegral[Yank] {
 
-  def valueUnit = Momentum.valueUnit
+  def dimension = Momentum
+
   protected def timeDerived = Newtons(toNewtonSeconds)
   protected def time = Seconds(1)
 
@@ -35,20 +36,21 @@ final class Momentum private (val value: Double)
   def toNewtonSeconds = to(NewtonSeconds)
 }
 
-object Momentum extends QuantityCompanion[Momentum] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Momentum(num.toDouble(n))
-  def apply(m: Mass, v: Velocity) = new Momentum(m.toKilograms * v.toMetersPerSecond)
+object Momentum extends Dimension[Momentum] {
+  private[motion] def apply[A](n: A, unit: MomentumUnit)(implicit num: Numeric[A]) = new Momentum(num.toDouble(n), unit)
+  def apply(m: Mass, v: Velocity): Momentum = NewtonSeconds(m.toKilograms * v.toMetersPerSecond)
   def apply = parseString _
   def name = "Momentum"
-  def valueUnit = NewtonSeconds
+  def primaryUnit = NewtonSeconds
+  def siUnit = NewtonSeconds
   def units = Set(NewtonSeconds)
 }
 
 trait MomentumUnit extends UnitOfMeasure[Momentum] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Momentum(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Momentum(n, this)
 }
 
-object NewtonSeconds extends MomentumUnit with ValueUnit {
+object NewtonSeconds extends MomentumUnit with PrimaryUnit with SiUnit {
   val symbol = "Ns"
 }
 
@@ -59,5 +61,5 @@ object MomentumConversions {
     def newtonSeconds = NewtonSeconds(n)
   }
 
-  implicit object MomentumNumeric extends AbstractQuantityNumeric[Momentum](Momentum.valueUnit)
+  implicit object MomentumNumeric extends AbstractQuantityNumeric[Momentum](Momentum.primaryUnit)
 }

--- a/src/main/scala/squants/motion/Pressure.scala
+++ b/src/main/scala/squants/motion/Pressure.scala
@@ -17,9 +17,10 @@ import squants.space.{ SquareInches, SquareMeters }
  *
  * @param value Double
  */
-final class Pressure private (val value: Double) extends Quantity[Pressure] {
+final class Pressure private (val value: Double, val unit: PressureUnit)
+    extends Quantity[Pressure] {
 
-  def valueUnit = Pressure.valueUnit
+  def dimension = Pressure
 
   def *(that: Area): Force = Newtons(toPascals * that.toSquareMeters)
   def *(that: Time) = ??? // returns DynamicViscosity
@@ -30,19 +31,20 @@ final class Pressure private (val value: Double) extends Quantity[Pressure] {
   def toStandardAtmospheres = to(StandardAtmospheres)
 }
 
-object Pressure extends QuantityCompanion[Pressure] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Pressure(num.toDouble(n))
+object Pressure extends Dimension[Pressure] {
+  private[motion] def apply[A](n: A, unit: PressureUnit)(implicit num: Numeric[A]) = new Pressure(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Pressure"
-  def valueUnit = Pascals
+  def primaryUnit = Pascals
+  def siUnit = Pascals
   def units = Set(Pascals, Bars, PoundsPerSquareInch, StandardAtmospheres)
 }
 
 trait PressureUnit extends UnitOfMeasure[Pressure] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Pressure(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Pressure(n, this)
 }
 
-object Pascals extends PressureUnit with ValueUnit {
+object Pascals extends PressureUnit with PrimaryUnit with SiUnit {
   val symbol = "Pa"
 }
 
@@ -74,5 +76,5 @@ object PressureConversions {
     def atm = StandardAtmospheres(n)
   }
 
-  implicit object PressureNumeric extends AbstractQuantityNumeric[Pressure](Pressure.valueUnit)
+  implicit object PressureNumeric extends AbstractQuantityNumeric[Pressure](Pressure.primaryUnit)
 }

--- a/src/main/scala/squants/motion/Velocity.scala
+++ b/src/main/scala/squants/motion/Velocity.scala
@@ -22,13 +22,14 @@ import squants.time.Seconds
  *
  * @param value Double
  */
-final class Velocity private (val value: Double)
+final class Velocity private (val value: Double, val unit: VelocityUnit)
     extends Quantity[Velocity]
     with TimeIntegral[Acceleration]
     with SecondTimeIntegral[Jerk]
     with TimeDerivative[Length] {
 
-  def valueUnit = Velocity.valueUnit
+  def dimension = Velocity
+
   def timeDerived = MetersPerSecondSquared(toMetersPerSecond)
   def timeIntegrated = Meters(toMetersPerSecond)
   def time = Seconds(1)
@@ -45,18 +46,19 @@ final class Velocity private (val value: Double)
   def toKnots = to(Knots)
 }
 
-object Velocity extends QuantityCompanion[Velocity] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Velocity(num.toDouble(n))
+object Velocity extends Dimension[Velocity] {
+  private[motion] def apply[A](n: A, unit: VelocityUnit)(implicit num: Numeric[A]) = new Velocity(num.toDouble(n), unit)
   def apply(l: Length, t: Time) = MetersPerSecond(l.toMeters / t.toSeconds)
   def apply = parseString _
   def name = "Velocity"
-  def valueUnit = MetersPerSecond
+  def primaryUnit = MetersPerSecond
+  def siUnit = MetersPerSecond
   def units = Set(MetersPerSecond, FeetPerSecond, KilometersPerHour, UsMilesPerHour,
     InternationalMilesPerHour, Knots)
 }
 
 trait VelocityUnit extends UnitOfMeasure[Velocity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]): Velocity = Velocity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]): Velocity = Velocity(n, this)
 }
 
 object FeetPerSecond extends VelocityUnit {
@@ -64,7 +66,7 @@ object FeetPerSecond extends VelocityUnit {
   val conversionFactor = Feet.conversionFactor * Meters.conversionFactor
 }
 
-object MetersPerSecond extends VelocityUnit with ValueUnit {
+object MetersPerSecond extends VelocityUnit with PrimaryUnit with SiUnit {
   val symbol = "m/s"
 }
 
@@ -103,5 +105,5 @@ object VelocityConversions {
     def knots = Knots(n)
   }
 
-  implicit object VelocityNumeric extends AbstractQuantityNumeric[Velocity](Velocity.valueUnit)
+  implicit object VelocityNumeric extends AbstractQuantityNumeric[Velocity](Velocity.primaryUnit)
 }

--- a/src/main/scala/squants/motion/VolumeFlowRate.scala
+++ b/src/main/scala/squants/motion/VolumeFlowRate.scala
@@ -19,10 +19,12 @@ import squants.Seconds
  *
  * @param value Double
  */
-final class VolumeFlowRate private (val value: Double) extends Quantity[VolumeFlowRate]
+final class VolumeFlowRate private (val value: Double, val unit: VolumeFlowRateUnit)
+    extends Quantity[VolumeFlowRate]
     with TimeDerivative[Volume] {
 
-  def valueUnit = CubicMetersPerSecond
+  def dimension = VolumeFlowRate
+
   protected def timeIntegrated = CubicMeters(toCubicMetersPerSecond)
   protected[squants] def time = Seconds(1)
 
@@ -33,19 +35,20 @@ final class VolumeFlowRate private (val value: Double) extends Quantity[VolumeFl
   def toGallonsPerSecond = to(GallonsPerSecond)
 }
 
-object VolumeFlowRate extends QuantityCompanion[VolumeFlowRate] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new VolumeFlowRate(num.toDouble(n))
+object VolumeFlowRate extends Dimension[VolumeFlowRate] {
+  private[motion] def apply[A](n: A, unit: VolumeFlowRateUnit)(implicit num: Numeric[A]) = new VolumeFlowRate(num.toDouble(n), unit)
   def apply = parseString _
   def name = "VolumeFlowRate"
-  def valueUnit = CubicMetersPerSecond
+  def primaryUnit = CubicMetersPerSecond
+  def siUnit = CubicMetersPerSecond
   def units = Set(CubicMetersPerSecond, GallonsPerDay, GallonsPerHour, GallonsPerMinute, GallonsPerSecond)
 }
 
 trait VolumeFlowRateUnit extends UnitOfMeasure[VolumeFlowRate] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = VolumeFlowRate(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = VolumeFlowRate(n, this)
 }
 
-object CubicMetersPerSecond extends VolumeFlowRateUnit with ValueUnit {
+object CubicMetersPerSecond extends VolumeFlowRateUnit with PrimaryUnit with SiUnit {
   val symbol = "m³/s"
 }
 

--- a/src/main/scala/squants/motion/Yank.scala
+++ b/src/main/scala/squants/motion/Yank.scala
@@ -17,12 +17,13 @@ import squants.time.{ SecondTimeDerivative, TimeSquared, TimeDerivative }
  *
  * @param value Double
  */
-final class Yank private (val value: Double)
+final class Yank private (val value: Double, val unit: YankUnit)
     extends Quantity[Yank]
     with TimeDerivative[Force]
     with SecondTimeDerivative[Momentum] {
 
-  def valueUnit = Yank.valueUnit
+  def dimension = Yank
+
   protected def timeIntegrated = Newtons(toNewtonsPerSecond)
   protected[squants] def time = Seconds(1)
 
@@ -31,19 +32,20 @@ final class Yank private (val value: Double)
   def toNewtonsPerSecond = to(NewtonsPerSecond)
 }
 
-object Yank extends QuantityCompanion[Yank] {
-  private[motion] def apply[A](n: A)(implicit num: Numeric[A]) = new Yank(num.toDouble(n))
+object Yank extends Dimension[Yank] {
+  private[motion] def apply[A](n: A, unit: YankUnit)(implicit num: Numeric[A]) = new Yank(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Yank"
-  def valueUnit = NewtonsPerSecond
+  def primaryUnit = NewtonsPerSecond
+  def siUnit = NewtonsPerSecond
   def units = Set(NewtonsPerSecond)
 }
 
 trait YankUnit extends UnitOfMeasure[Yank] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Yank(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Yank(n, this)
 }
 
-object NewtonsPerSecond extends YankUnit with ValueUnit {
+object NewtonsPerSecond extends YankUnit with PrimaryUnit with SiUnit {
   val symbol = "N/s"
 }
 
@@ -54,5 +56,5 @@ object YankConversions {
     def newtonsPerSecond = NewtonsPerSecond(n)
   }
 
-  implicit object YankNumeric extends AbstractQuantityNumeric[Yank](Yank.valueUnit)
+  implicit object YankNumeric extends AbstractQuantityNumeric[Yank](Yank.primaryUnit)
 }

--- a/src/main/scala/squants/photo/Illuminance.scala
+++ b/src/main/scala/squants/photo/Illuminance.scala
@@ -16,10 +16,12 @@ import squants.time.TimeDerivative
  *
  * @param value value in [[squants.photo.Lux]]
  */
-final class Illuminance private (val value: Double) extends Quantity[Illuminance]
+final class Illuminance private (val value: Double, val unit: IlluminanceUnit)
+    extends Quantity[Illuminance]
     with TimeDerivative[LuminousExposure] {
 
-  def valueUnit = Illuminance.valueUnit
+  def dimension = Illuminance
+
   protected def timeIntegrated = LuxSeconds(toLux)
   protected[squants] def time = Seconds(1)
 
@@ -28,19 +30,20 @@ final class Illuminance private (val value: Double) extends Quantity[Illuminance
   def toLux = to(Lux)
 }
 
-object Illuminance extends QuantityCompanion[Illuminance] {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new Illuminance(num.toDouble(n))
+object Illuminance extends Dimension[Illuminance] {
+  private[photo] def apply[A](n: A, unit: IlluminanceUnit)(implicit num: Numeric[A]) = new Illuminance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Illuminance"
-  def valueUnit = Lux
+  def primaryUnit = Lux
+  def siUnit = Lux
   def units = Set(Lux)
 }
 
 trait IlluminanceUnit extends UnitOfMeasure[Illuminance] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Illuminance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Illuminance(n, this)
 }
 
-object Lux extends IlluminanceUnit with ValueUnit {
+object Lux extends IlluminanceUnit with PrimaryUnit with SiUnit {
   val symbol = "lx"
 }
 
@@ -51,5 +54,5 @@ object IlluminanceConversions {
     def lux = Lux(n)
   }
 
-  implicit object IlluminanceNumeric extends AbstractQuantityNumeric[Illuminance](Illuminance.valueUnit)
+  implicit object IlluminanceNumeric extends AbstractQuantityNumeric[Illuminance](Illuminance.primaryUnit)
 }

--- a/src/main/scala/squants/photo/Luminance.scala
+++ b/src/main/scala/squants/photo/Luminance.scala
@@ -15,29 +15,31 @@ import squants._
  *
  * @param value Double
  */
-final class Luminance private (val value: Double) extends Quantity[Luminance] {
+final class Luminance private (val value: Double, val unit: LuminanceUnit)
+    extends Quantity[Luminance] {
 
-  def valueUnit = Luminance.valueUnit
+  def dimension = Luminance
 
   def *(that: Area): LuminousIntensity = Candelas(value * that.toSquareMeters)
 
   def toCandelasPerSquareMeters = to(CandelasPerSquareMeter)
 }
 
-object Luminance extends QuantityCompanion[Luminance] {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new Luminance(num.toDouble(n))
+object Luminance extends Dimension[Luminance] {
+  private[photo] def apply[A](n: A, unit: LuminanceUnit)(implicit num: Numeric[A]) = new Luminance(num.toDouble(n), unit)
   def apply = parseString _
 
   def name = "Luminance"
-  def valueUnit = CandelasPerSquareMeter
+  def primaryUnit = CandelasPerSquareMeter
+  def siUnit = CandelasPerSquareMeter
   def units = Set(CandelasPerSquareMeter)
 }
 
 trait LuminanceUnit extends UnitOfMeasure[Luminance] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Luminance(num.toDouble(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Luminance(num.toDouble(n), this)
 }
 
-object CandelasPerSquareMeter extends LuminanceUnit with ValueUnit {
+object CandelasPerSquareMeter extends LuminanceUnit with PrimaryUnit with SiUnit {
   val symbol = "cd/m²"
 }
 
@@ -48,6 +50,6 @@ object LuminanceConversions {
     def candelasPerSquareMeter = CandelasPerSquareMeter(n)
   }
 
-  implicit object LuminanceNumeric extends AbstractQuantityNumeric[Luminance](Luminance.valueUnit)
+  implicit object LuminanceNumeric extends AbstractQuantityNumeric[Luminance](Luminance.primaryUnit)
 }
 

--- a/src/main/scala/squants/photo/LuminousEnergy.scala
+++ b/src/main/scala/squants/photo/LuminousEnergy.scala
@@ -16,29 +16,32 @@ import squants.time.{ Seconds, Time, TimeIntegral }
  *
  * @param value value in [[squants.photo.LumenSeconds]]
  */
-final class LuminousEnergy private (val value: Double)
+final class LuminousEnergy private (val value: Double, val unit: LuminousEnergyUnit)
     extends Quantity[LuminousEnergy]
     with TimeIntegral[LuminousFlux] {
 
-  def valueUnit = LuminousEnergy.valueUnit
+  def dimension = LuminousEnergy
+
   protected def timeDerived = Lumens(toLumenSeconds)
   protected[squants] def time = Seconds(1)
 
   def toLumenSeconds = to(LumenSeconds)
 }
 
-object LuminousEnergy extends QuantityCompanion[LuminousEnergy] {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new LuminousEnergy(num.toDouble(n))
+object LuminousEnergy extends Dimension[LuminousEnergy] {
+  private[photo] def apply[A](n: A, unit: LuminousEnergyUnit)(implicit num: Numeric[A]) = new LuminousEnergy(num.toDouble(n), unit)
   def apply = parseString _
   def name = "LuminousEnergy"
-  def valueUnit = LumenSeconds
+  def primaryUnit = LumenSeconds
+  def siUnit = LumenSeconds
   def units = Set(LumenSeconds)
 }
 
-trait LuminousEnergyUnit extends UnitOfMeasure[LuminousEnergy] with UnitConverter
+trait LuminousEnergyUnit extends UnitOfMeasure[LuminousEnergy] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousEnergy(num.toDouble(n), this)
+}
 
-object LumenSeconds extends LuminousEnergyUnit with ValueUnit {
-  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousEnergy(n)
+object LumenSeconds extends LuminousEnergyUnit with PrimaryUnit with SiUnit {
   val symbol = "lm⋅s"
 }
 
@@ -49,5 +52,5 @@ object LuminousEnergyConversions {
     def lumenSeconds = LumenSeconds(n)
   }
 
-  implicit object LuminousEnergyNumeric extends AbstractQuantityNumeric[LuminousEnergy](LuminousEnergy.valueUnit)
+  implicit object LuminousEnergyNumeric extends AbstractQuantityNumeric[LuminousEnergy](LuminousEnergy.primaryUnit)
 }

--- a/src/main/scala/squants/photo/LuminousExposure.scala
+++ b/src/main/scala/squants/photo/LuminousExposure.scala
@@ -17,29 +17,32 @@ import squants.time.TimeIntegral
  *
  * @param value value in [[squants.photo.LuxSeconds]]
  */
-final class LuminousExposure private (val value: Double) extends Quantity[LuminousExposure]
+final class LuminousExposure private (val value: Double, val unit: LuminousExposureUnit)
+    extends Quantity[LuminousExposure]
     with TimeIntegral[Illuminance] {
 
-  def valueUnit = LuminousExposure.valueUnit
+  def dimension = LuminousExposure
+
   protected def timeDerived = Lux(toLuxSeconds)
   protected[squants] def time = Seconds(1)
 
   def toLuxSeconds = to(LuxSeconds)
 }
 
-object LuminousExposure extends QuantityCompanion[LuminousExposure] {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new LuminousExposure(num.toDouble(n))
+object LuminousExposure extends Dimension[LuminousExposure] {
+  private[photo] def apply[A](n: A, unit: LuminousExposureUnit)(implicit num: Numeric[A]) = new LuminousExposure(num.toDouble(n), unit)
   def apply = parseString _
   def name = "LuminousExposure"
-  def valueUnit = LuxSeconds
+  def primaryUnit = LuxSeconds
+  def siUnit = LuxSeconds
   def units = Set(LuxSeconds)
 }
 
 trait LuminousExposureUnit extends UnitOfMeasure[LuminousExposure] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousExposure(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousExposure(n, this)
 }
 
-object LuxSeconds extends LuminousExposureUnit with ValueUnit {
+object LuxSeconds extends LuminousExposureUnit with PrimaryUnit with SiUnit {
   val symbol = "lx⋅s"
 }
 
@@ -50,5 +53,5 @@ object LuminousExposureConversions {
     def luxSeconds = LuxSeconds(n)
   }
 
-  implicit object LuminousExposureNumeric extends AbstractQuantityNumeric[LuminousExposure](LuminousExposure.valueUnit)
+  implicit object LuminousExposureNumeric extends AbstractQuantityNumeric[LuminousExposure](LuminousExposure.primaryUnit)
 }

--- a/src/main/scala/squants/photo/LuminousFlux.scala
+++ b/src/main/scala/squants/photo/LuminousFlux.scala
@@ -18,11 +18,12 @@ import squants.space.{ SquaredRadians, SquareMeters }
  *
  * @param value value in [[squants.photo.Lumens]]
  */
-final class LuminousFlux private (val value: Double)
+final class LuminousFlux private (val value: Double, val unit: LuminousFluxUnit)
     extends Quantity[LuminousFlux]
     with TimeDerivative[LuminousEnergy] {
 
-  def valueUnit = LuminousFlux.valueUnit
+  def dimension = LuminousFlux
+
   protected def timeIntegrated = LumenSeconds(toLumens)
   protected[squants] def time = Seconds(1)
 
@@ -34,18 +35,20 @@ final class LuminousFlux private (val value: Double)
   def toLumens = to(Lumens)
 }
 
-object LuminousFlux extends QuantityCompanion[LuminousFlux] {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new LuminousFlux(num.toDouble(n))
+object LuminousFlux extends Dimension[LuminousFlux] {
+  private[photo] def apply[A](n: A, unit: LuminousFluxUnit)(implicit num: Numeric[A]) = new LuminousFlux(num.toDouble(n), unit)
   def apply = parseString _
   def name = "LuminousFlux"
-  def valueUnit = Lumens
+  def primaryUnit = Lumens
+  def siUnit = Lumens
   def units = Set(Lumens)
 }
 
-trait LuminousFluxUnit extends UnitOfMeasure[LuminousFlux] with UnitConverter
+trait LuminousFluxUnit extends UnitOfMeasure[LuminousFlux] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousFlux(n, this)
+}
 
-object Lumens extends LuminousFluxUnit with ValueUnit {
-  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousFlux(n)
+object Lumens extends LuminousFluxUnit with PrimaryUnit with SiUnit {
   val symbol = "lm"
 }
 
@@ -56,5 +59,5 @@ object LuminousFluxConversions {
     def lumens = Lumens(n)
   }
 
-  implicit object LuminousFluxNumeric extends AbstractQuantityNumeric[LuminousFlux](LuminousFlux.valueUnit)
+  implicit object LuminousFluxNumeric extends AbstractQuantityNumeric[LuminousFlux](LuminousFlux.primaryUnit)
 }

--- a/src/main/scala/squants/photo/LuminousIntensity.scala
+++ b/src/main/scala/squants/photo/LuminousIntensity.scala
@@ -16,9 +16,10 @@ import squants.space.{ SquareMeters, SolidAngle }
  *
  * @param value value in [[squants.photo.Candelas]]
  */
-final class LuminousIntensity private (val value: Double) extends Quantity[LuminousIntensity] {
+final class LuminousIntensity private (val value: Double, val unit: LuminousIntensityUnit)
+    extends Quantity[LuminousIntensity] {
 
-  def valueUnit = LuminousIntensity.valueUnit
+  def dimension = LuminousIntensity
 
   def *(that: SolidAngle): LuminousFlux = Lumens(toCandelas * that.toSquaredRadians)
   def /(that: Area): Luminance = CandelasPerSquareMeter(toCandelas / that.toSquareMeters)
@@ -27,21 +28,21 @@ final class LuminousIntensity private (val value: Double) extends Quantity[Lumin
   def toCandelas = to(Candelas)
 }
 
-object LuminousIntensity extends QuantityCompanion[LuminousIntensity] with BaseQuantity {
-  private[photo] def apply[A](n: A)(implicit num: Numeric[A]) = new LuminousIntensity(num.toDouble(n))
+object LuminousIntensity extends Dimension[LuminousIntensity] with BaseDimension {
+  private[photo] def apply[A](n: A, unit: LuminousIntensityUnit)(implicit num: Numeric[A]) = new LuminousIntensity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "LuminousIntensity"
-  def valueUnit = Candelas
+  def primaryUnit = Candelas
   def units = Set(Candelas)
-  def baseUnit = Candelas
+  def siUnit = Candelas
   def dimensionSymbol = "J"
 }
 
 trait LuminousIntensityUnit extends UnitOfMeasure[LuminousIntensity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousIntensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = LuminousIntensity(n, this)
 }
 
-object Candelas extends LuminousIntensityUnit with ValueUnit with BaseUnit {
+object Candelas extends LuminousIntensityUnit with PrimaryUnit with SiBaseUnit {
   val symbol = "cd"
 }
 
@@ -52,5 +53,5 @@ object LuminousIntensityConversions {
     def candelas = Candelas(n)
   }
 
-  implicit object LuminousIntensityNumeric extends AbstractQuantityNumeric[LuminousIntensity](LuminousIntensity.valueUnit)
+  implicit object LuminousIntensityNumeric extends AbstractQuantityNumeric[LuminousIntensity](LuminousIntensity.primaryUnit)
 }

--- a/src/main/scala/squants/radio/Irradiance.scala
+++ b/src/main/scala/squants/radio/Irradiance.scala
@@ -18,9 +18,10 @@ import squants.space.SquareMeters
  *
  * @param value Double
  */
-final class Irradiance private (val value: Double) extends Quantity[Irradiance] {
+final class Irradiance private (val value: Double, val unit: IrradianceUnit)
+    extends Quantity[Irradiance] {
 
-  def valueUnit = Irradiance.valueUnit
+  def dimension = Irradiance
 
   def *(that: Area): Power = Watts(toWattsPerSquareMeter * that.toSquareMeters)
   def /(that: Power): Area = SquareMeters(toWattsPerSquareMeter / that.toWatts)
@@ -28,19 +29,20 @@ final class Irradiance private (val value: Double) extends Quantity[Irradiance] 
   def toWattsPerSquareMeter = to(WattsPerSquareMeter)
 }
 
-object Irradiance extends QuantityCompanion[Irradiance] {
-  private[radio] def apply[A](n: A)(implicit num: Numeric[A]) = new Irradiance(num.toDouble(n))
+object Irradiance extends Dimension[Irradiance] {
+  private[radio] def apply[A](n: A, unit: IrradianceUnit)(implicit num: Numeric[A]) = new Irradiance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Irradiance"
-  def valueUnit = WattsPerSquareMeter
+  def primaryUnit = WattsPerSquareMeter
+  def siUnit = WattsPerSquareMeter
   def units = Set(WattsPerSquareMeter)
 }
 
 trait IrradianceUnit extends UnitOfMeasure[Irradiance] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Irradiance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Irradiance(n, this)
 }
 
-object WattsPerSquareMeter extends IrradianceUnit with ValueUnit {
+object WattsPerSquareMeter extends IrradianceUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + SquareMeters.symbol
 }
 
@@ -51,5 +53,5 @@ object IrradianceConversions {
     def wattsPerSquareMeter = WattsPerSquareMeter(n)
   }
 
-  implicit object IrradianceNumeric extends AbstractQuantityNumeric[Irradiance](Irradiance.valueUnit)
+  implicit object IrradianceNumeric extends AbstractQuantityNumeric[Irradiance](Irradiance.primaryUnit)
 }

--- a/src/main/scala/squants/radio/Radiance.scala
+++ b/src/main/scala/squants/radio/Radiance.scala
@@ -18,9 +18,10 @@ import squants.space.{ SquareMeters, SquaredRadians }
  *
  * @param value Double
  */
-final class Radiance private (val value: Double) extends Quantity[Radiance] {
+final class Radiance private (val value: Double, val unit: RadianceUnit)
+    extends Quantity[Radiance] {
 
-  def valueUnit = Radiance.valueUnit
+  def dimension = Radiance
 
   def *(that: Area): RadiantIntensity = WattsPerSteradian(toWattsPerSteradianPerSquareMeter * that.toSquareMeters)
   def /(that: RadiantIntensity): Area = SquareMeters(toWattsPerSteradianPerSquareMeter / that.toWattsPerSteradian)
@@ -28,19 +29,20 @@ final class Radiance private (val value: Double) extends Quantity[Radiance] {
   def toWattsPerSteradianPerSquareMeter = to(WattsPerSteradianPerSquareMeter)
 }
 
-object Radiance extends QuantityCompanion[Radiance] {
-  private[radio] def apply[A](n: A)(implicit num: Numeric[A]) = new Radiance(num.toDouble(n))
+object Radiance extends Dimension[Radiance] {
+  private[radio] def apply[A](n: A, unit: RadianceUnit)(implicit num: Numeric[A]) = new Radiance(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Radiance"
-  def valueUnit = WattsPerSteradianPerSquareMeter
+  def primaryUnit = WattsPerSteradianPerSquareMeter
+  def siUnit = WattsPerSteradianPerSquareMeter
   def units = Set(WattsPerSteradianPerSquareMeter)
 }
 
 trait RadianceUnit extends UnitOfMeasure[Radiance] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Radiance(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Radiance(n, this)
 }
 
-object WattsPerSteradianPerSquareMeter extends RadianceUnit with ValueUnit {
+object WattsPerSteradianPerSquareMeter extends RadianceUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + SquaredRadians.symbol + "/" + SquareMeters.symbol
 }
 
@@ -51,6 +53,6 @@ object RadianceConversions {
     def wattsPerSteradianPerSquareMeter = WattsPerSteradianPerSquareMeter(n)
   }
 
-  implicit object RadianceNumeric extends AbstractQuantityNumeric[Radiance](Radiance.valueUnit)
+  implicit object RadianceNumeric extends AbstractQuantityNumeric[Radiance](Radiance.primaryUnit)
 }
 

--- a/src/main/scala/squants/radio/RadiantIntensity.scala
+++ b/src/main/scala/squants/radio/RadiantIntensity.scala
@@ -18,9 +18,10 @@ import squants.space.{ SquareMeters, SquaredRadians }
  *
  * @param value Double
  */
-final class RadiantIntensity private (val value: Double) extends Quantity[RadiantIntensity] {
+final class RadiantIntensity private (val value: Double, val unit: RadiantIntensityUnit)
+    extends Quantity[RadiantIntensity] {
 
-  def valueUnit = RadiantIntensity.valueUnit
+  def dimension = RadiantIntensity
 
   def *(that: SolidAngle): Power = Watts(toWattsPerSteradian * that.toSquaredRadians)
   def /(that: Power): SolidAngle = SquareRadians(toWattsPerSteradian / that.toWatts)
@@ -32,19 +33,20 @@ final class RadiantIntensity private (val value: Double) extends Quantity[Radian
   def toWattsPerSteradian = to(WattsPerSteradian)
 }
 
-object RadiantIntensity extends QuantityCompanion[RadiantIntensity] {
-  private[radio] def apply[A](n: A)(implicit num: Numeric[A]) = new RadiantIntensity(num.toDouble(n))
+object RadiantIntensity extends Dimension[RadiantIntensity] {
+  private[radio] def apply[A](n: A, unit: RadiantIntensityUnit)(implicit num: Numeric[A]) = new RadiantIntensity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "RadiantIntensity"
-  def valueUnit = WattsPerSteradian
+  def primaryUnit = WattsPerSteradian
+  def siUnit = WattsPerSteradian
   def units = Set(WattsPerSteradian)
 }
 
 trait RadiantIntensityUnit extends UnitOfMeasure[RadiantIntensity] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = RadiantIntensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = RadiantIntensity(n, this)
 }
 
-object WattsPerSteradian extends RadiantIntensityUnit with ValueUnit {
+object WattsPerSteradian extends RadiantIntensityUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + SquaredRadians.symbol
 }
 
@@ -55,6 +57,6 @@ object RadiantIntensityConversions {
     def wattsPerSteradian = WattsPerSteradian(n)
   }
 
-  implicit object RadiantIntensityNumeric extends AbstractQuantityNumeric[RadiantIntensity](RadiantIntensity.valueUnit)
+  implicit object RadiantIntensityNumeric extends AbstractQuantityNumeric[RadiantIntensity](RadiantIntensity.primaryUnit)
 }
 

--- a/src/main/scala/squants/radio/SpectralIntensity.scala
+++ b/src/main/scala/squants/radio/SpectralIntensity.scala
@@ -18,9 +18,10 @@ import squants.space.{ Meters, SquaredRadians }
  *
  * @param value Double
  */
-final class SpectralIntensity private (val value: Double) extends Quantity[SpectralIntensity] {
+final class SpectralIntensity private (val value: Double, val unit: SpectralIntensityUnit)
+    extends Quantity[SpectralIntensity] {
 
-  def valueUnit = SpectralIntensity.valueUnit
+  def dimension = SpectralIntensity
 
   def *(that: Length): RadiantIntensity = WattsPerSteradian(toWattsPerSteradianPerMeter * that.toMeters)
   def /(that: RadiantIntensity): Length = Meters(toWattsPerSteradianPerMeter / that.toWattsPerSteradian)
@@ -28,19 +29,20 @@ final class SpectralIntensity private (val value: Double) extends Quantity[Spect
   def toWattsPerSteradianPerMeter = to(WattsPerSteradianPerMeter)
 }
 
-object SpectralIntensity extends QuantityCompanion[SpectralIntensity] {
-  private[radio] def apply[A](n: A)(implicit num: Numeric[A]) = new SpectralIntensity(num.toDouble(n))
+object SpectralIntensity extends Dimension[SpectralIntensity] {
+  private[radio] def apply[A](n: A, unit: SpectralIntensityUnit)(implicit num: Numeric[A]) = new SpectralIntensity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "SpectralIntensity"
-  def valueUnit = WattsPerSteradianPerMeter
+  def primaryUnit = WattsPerSteradianPerMeter
+  def siUnit = WattsPerSteradianPerMeter
   def units = Set(WattsPerSteradianPerMeter)
 }
 
 trait SpectralIntensityUnit extends UnitOfMeasure[SpectralIntensity] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = SpectralIntensity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = SpectralIntensity(n, this)
 }
 
-object WattsPerSteradianPerMeter extends SpectralIntensityUnit with ValueUnit {
+object WattsPerSteradianPerMeter extends SpectralIntensityUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + SquaredRadians.symbol + "/" + Meters.symbol
 }
 
@@ -51,6 +53,6 @@ object SpectralIntensityConversions {
     def wattsPerSteradianPerMeter = WattsPerSteradianPerMeter(n)
   }
 
-  implicit object SpectralIntensityNumeric extends AbstractQuantityNumeric[SpectralIntensity](SpectralIntensity.valueUnit)
+  implicit object SpectralIntensityNumeric extends AbstractQuantityNumeric[SpectralIntensity](SpectralIntensity.primaryUnit)
 }
 

--- a/src/main/scala/squants/radio/SpectralPower.scala
+++ b/src/main/scala/squants/radio/SpectralPower.scala
@@ -18,9 +18,10 @@ import squants.space.Meters
  *
  * @param value Double
  */
-final class SpectralPower private (val value: Double) extends Quantity[SpectralPower] {
+final class SpectralPower private (val value: Double, val unit: SpectralPowerUnit)
+    extends Quantity[SpectralPower] {
 
-  def valueUnit = SpectralPower.valueUnit
+  def dimension = SpectralPower
 
   def *(that: Length): Power = Watts(toWattsPerMeter * that.toMeters)
   def /(that: Power): Length = Meters(toWattsPerMeter / that.toWatts)
@@ -28,19 +29,20 @@ final class SpectralPower private (val value: Double) extends Quantity[SpectralP
   def toWattsPerMeter = value
 }
 
-object SpectralPower extends QuantityCompanion[SpectralPower] {
-  private[radio] def apply[A](n: A)(implicit num: Numeric[A]) = new SpectralPower(num.toDouble(n))
+object SpectralPower extends Dimension[SpectralPower] {
+  private[radio] def apply[A](n: A, unit: SpectralPowerUnit)(implicit num: Numeric[A]) = new SpectralPower(num.toDouble(n), unit)
   def apply = parseString _
   def name = "SpectralPower"
-  def valueUnit = WattsPerMeter
+  def primaryUnit = WattsPerMeter
+  def siUnit = WattsPerMeter
   def units = Set(WattsPerMeter)
 }
 
 trait SpectralPowerUnit extends UnitOfMeasure[SpectralPower] {
-  def apply[A](n: A)(implicit num: Numeric[A]) = SpectralPower(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = SpectralPower(n, this)
 }
 
-object WattsPerMeter extends SpectralPowerUnit with ValueUnit {
+object WattsPerMeter extends SpectralPowerUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + Meters.symbol
 }
 
@@ -51,6 +53,6 @@ object SpectralPowerConversions {
     def wattsPerMeter = WattsPerMeter(n)
   }
 
-  implicit object SpectralPowerNumeric extends AbstractQuantityNumeric[SpectralPower](SpectralPower.valueUnit)
+  implicit object SpectralPowerNumeric extends AbstractQuantityNumeric[SpectralPower](SpectralPower.primaryUnit)
 }
 

--- a/src/main/scala/squants/space/Angle.scala
+++ b/src/main/scala/squants/space/Angle.scala
@@ -16,10 +16,10 @@ import squants._
  *
  * @param value value in [[squants.space.Radians]]
  */
-final class Angle private (val value: Double)
+final class Angle private (val value: Double, val unit: AngleUnit)
     extends Quantity[Angle] {
 
-  def valueUnit = Angle.valueUnit
+  def dimension = Angle
 
   def toRadians = to(Radians)
   def toDegrees = to(Degrees)
@@ -35,19 +35,20 @@ final class Angle private (val value: Double)
   def acos = math.acos(toRadians)
 }
 
-object Angle extends QuantityCompanion[Angle] {
-  private[space] def apply[A](n: A)(implicit num: Numeric[A]) = new Angle(num.toDouble(n))
+object Angle extends Dimension[Angle] {
+  private[space] def apply[A](n: A, unit: AngleUnit)(implicit num: Numeric[A]) = new Angle(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Angle"
-  def valueUnit = Radians
+  def primaryUnit = Radians
+  def siUnit = Radians
   def units = Set(Radians, Degrees, Gradians, Turns, Arcminutes, Arcseconds)
 }
 
 trait AngleUnit extends UnitOfMeasure[Angle] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Angle(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Angle(n, this)
 }
 
-object Radians extends AngleUnit with ValueUnit {
+object Radians extends AngleUnit with PrimaryUnit with SiUnit {
   val symbol = "rad"
 }
 
@@ -93,5 +94,5 @@ object AngleConversions {
     def arcseconds = Arcseconds(n)
   }
 
-  implicit object AngleNumeric extends AbstractQuantityNumeric[Angle](Angle.valueUnit)
+  implicit object AngleNumeric extends AbstractQuantityNumeric[Angle](Angle.primaryUnit)
 }

--- a/src/main/scala/squants/space/SolidAngle.scala
+++ b/src/main/scala/squants/space/SolidAngle.scala
@@ -19,9 +19,10 @@ import squants.radio.RadiantIntensity
  *
  * @param value value in [[squants.space.SquaredRadians]]
  */
-final class SolidAngle private (val value: Double) extends Quantity[SolidAngle] {
+final class SolidAngle private (val value: Double, val unit: SolidAngleUnit)
+    extends Quantity[SolidAngle] {
 
-  def valueUnit = SolidAngle.valueUnit
+  def dimension = SolidAngle
 
   def *(that: LuminousIntensity): LuminousFlux = Lumens(toSquaredRadians * that.toCandelas)
   def *(that: RadiantIntensity): Power = Watts(toSquaredRadians * that.toWattsPerSteradian)
@@ -30,18 +31,20 @@ final class SolidAngle private (val value: Double) extends Quantity[SolidAngle] 
   def toSteradians = value
 }
 
-object SolidAngle extends QuantityCompanion[SolidAngle] {
-  private[space] def apply[A](n: A)(implicit num: Numeric[A]) = new SolidAngle(num.toDouble(n))
+object SolidAngle extends Dimension[SolidAngle] {
+  private[space] def apply[A](n: A, unit: SolidAngleUnit)(implicit num: Numeric[A]) = new SolidAngle(num.toDouble(n), unit)
   def apply = parseString _
   def name = "SolidAngle"
-  def valueUnit = SquareRadians
+  def primaryUnit = SquareRadians
+  def siUnit = SquareRadians
   def units = Set(SquareRadians)
 }
 
-trait SolidAngleUnit extends UnitOfMeasure[SolidAngle]
+trait SolidAngleUnit extends UnitOfMeasure[SolidAngle] {
+  def apply[A](n: A)(implicit num: Numeric[A]) = SolidAngle(n, this)
+}
 
-object SquaredRadians extends SolidAngleUnit with ValueUnit {
-  def apply[A](n: A)(implicit num: Numeric[A]) = SolidAngle(n)
+object SquaredRadians extends SolidAngleUnit with PrimaryUnit with SiUnit {
   val symbol = "sr"
 }
 
@@ -54,6 +57,6 @@ object SolidAngleConversions {
     def steradians = SquaredRadians(n)
   }
 
-  implicit object SolidAngleNumeric extends AbstractQuantityNumeric[SolidAngle](SolidAngle.valueUnit)
+  implicit object SolidAngleNumeric extends AbstractQuantityNumeric[SolidAngle](SolidAngle.primaryUnit)
 }
 

--- a/src/main/scala/squants/thermal/ThermalCapacity.scala
+++ b/src/main/scala/squants/thermal/ThermalCapacity.scala
@@ -21,28 +21,30 @@ import squants.energy.{ Energy, Joules }
  *
  * @param value the value in [[squants.thermal.JoulesPerKelvin]]
  */
-final class ThermalCapacity private (val value: Double) extends Quantity[ThermalCapacity] {
+final class ThermalCapacity private (val value: Double, val unit: ThermalCapacityUnit)
+    extends Quantity[ThermalCapacity] {
 
-  def valueUnit = ThermalCapacity.valueUnit
+  def dimension = ThermalCapacity
 
   def *(that: Temperature): Energy = Joules(toJoulesPerKelvin * that.toKelvinScale)
 
   def toJoulesPerKelvin = to(JoulesPerKelvin)
 }
 
-object ThermalCapacity extends QuantityCompanion[ThermalCapacity] {
-  private[thermal] def apply[A](n: A)(implicit num: Numeric[A]) = new ThermalCapacity(num.toDouble(n))
+object ThermalCapacity extends Dimension[ThermalCapacity] {
+  private[thermal] def apply[A](n: A, unit: ThermalCapacityUnit)(implicit num: Numeric[A]) = new ThermalCapacity(num.toDouble(n), unit)
   def apply = parseString _
   def name = "ThermalCapacity"
-  def valueUnit = JoulesPerKelvin
+  def primaryUnit = JoulesPerKelvin
+  def siUnit = JoulesPerKelvin
   def units = Set(JoulesPerKelvin)
 }
 
 trait ThermalCapacityUnit extends UnitOfMeasure[ThermalCapacity] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = ThermalCapacity(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = ThermalCapacity(n, this)
 }
 
-object JoulesPerKelvin extends ThermalCapacityUnit with ValueUnit {
+object JoulesPerKelvin extends ThermalCapacityUnit with PrimaryUnit with SiUnit {
   def symbol = "J/K"
 }
 
@@ -53,5 +55,5 @@ object ThermalCapacityConversions {
     def joulesPerKelvin = JoulesPerKelvin(n)
   }
 
-  implicit object ThermalCapacityNumeric extends AbstractQuantityNumeric[ThermalCapacity](ThermalCapacity.valueUnit)
+  implicit object ThermalCapacityNumeric extends AbstractQuantityNumeric[ThermalCapacity](ThermalCapacity.primaryUnit)
 }

--- a/src/main/scala/squants/time/Frequency.scala
+++ b/src/main/scala/squants/time/Frequency.scala
@@ -18,9 +18,11 @@ import squants._
  *
  * @param value Double
  */
-final class Frequency private (val value: Double) extends Quantity[Frequency] with TimeDerivative[Dimensionless] {
+final class Frequency private (val value: Double, val unit: FrequencyUnit)
+    extends Quantity[Frequency] with TimeDerivative[Dimensionless] {
 
-  def valueUnit = Frequency.valueUnit
+  def dimension = Frequency
+
   protected def timeIntegrated = Each(toHertz)
   protected[squants] def time = Seconds(1)
 
@@ -32,19 +34,20 @@ final class Frequency private (val value: Double) extends Quantity[Frequency] wi
   def toRevolutionsPerMinute = to(RevolutionsPerMinute)
 }
 
-object Frequency extends QuantityCompanion[Frequency] {
-  private[time] def apply[A](n: A)(implicit num: Numeric[A]) = new Frequency(num.toDouble(n))
+object Frequency extends Dimension[Frequency] {
+  private[time] def apply[A](n: A, unit: FrequencyUnit)(implicit num: Numeric[A]) = new Frequency(num.toDouble(n), unit)
   def apply = parseString _
   def name = "Frequency"
-  def valueUnit = Hertz
+  def primaryUnit = Hertz
+  def siUnit = Hertz
   def units = Set(Hertz, Kilohertz, Megahertz, Gigahertz, Terahertz, RevolutionsPerMinute)
 }
 
 trait FrequencyUnit extends UnitOfMeasure[Frequency] with UnitConverter {
-  def apply[A](n: A)(implicit num: Numeric[A]) = Frequency(convertFrom(n))
+  def apply[A](n: A)(implicit num: Numeric[A]) = Frequency(n, this)
 }
 
-object Hertz extends FrequencyUnit with ValueUnit {
+object Hertz extends FrequencyUnit with PrimaryUnit with SiUnit {
   val symbol = "Hz"
 }
 
@@ -83,5 +86,5 @@ object FrequencyConversions {
     def rpm = RevolutionsPerMinute(n)
   }
 
-  implicit object FrequencyNumeric extends AbstractQuantityNumeric[Frequency](Frequency.valueUnit)
+  implicit object FrequencyNumeric extends AbstractQuantityNumeric[Frequency](Frequency.primaryUnit)
 }

--- a/src/test/scala/squants/QuantityChecks.scala
+++ b/src/test/scala/squants/QuantityChecks.scala
@@ -19,7 +19,7 @@ trait QuantityChecks {
 
   type TestData = Int
   val posNum = Gen.posNum[TestData]
-  val tol = 0.0000000000001
+  val tol = 1e-13
   implicit val tolTime = Seconds(tol)
 
 }

--- a/src/test/scala/squants/QuantitySpec.scala
+++ b/src/test/scala/squants/QuantitySpec.scala
@@ -22,21 +22,26 @@ class QuantitySpec extends FlatSpec with Matchers {
   /*
     Create a Quantity with two Units of Measure
    */
-  final class Thingee private (val value: Double) extends Quantity[Thingee] {
-    def valueUnit = Thangs
+  final class Thingee private (val value: Double, val unit: ThingeeUnit)
+      extends Quantity[Thingee] {
+    def dimension = Thingee
     def toThangs = to(Thangs)
     def toKilothangs = to(Kilothangs)
   }
 
-  object Thingee {
-    private[squants] def apply[A](n: A)(implicit num: Numeric[A]) = new Thingee(num.toDouble(n))
+  object Thingee extends Dimension[Thingee] {
+    private[squants] def apply[A](n: A, unit: ThingeeUnit)(implicit num: Numeric[A]) = new Thingee(num.toDouble(n), unit)
+    def name = "Thingee"
+    def primaryUnit = Thangs
+    def siUnit = Thangs
+    def units = Set(Thangs, Kilothangs)
   }
 
   trait ThingeeUnit extends UnitOfMeasure[Thingee] with UnitConverter {
-    def apply[A](n: A)(implicit num: Numeric[A]) = Thingee(convertFrom(n))
+    def apply[A](n: A)(implicit num: Numeric[A]) = Thingee(n, this)
   }
 
-  object Thangs extends ThingeeUnit with ValueUnit {
+  object Thangs extends ThingeeUnit with PrimaryUnit with SiUnit {
     val symbol = "th"
   }
 

--- a/src/test/scala/squants/VectorSpec.scala
+++ b/src/test/scala/squants/VectorSpec.scala
@@ -149,7 +149,6 @@ class VectorSpec extends FlatSpec with Matchers {
 
   it should "create a Vector with expected values" in {
     val vector = QuantityVector(Kilometers(1), Kilometers(10), Kilometers(5))
-    vector.valueUnit should be(Meters)
     vector.coordinates(0) should be(Kilometers(1))
     vector.coordinates(1) should be(Kilometers(10))
     vector.coordinates(2) should be(Kilometers(5))
@@ -177,11 +176,12 @@ class VectorSpec extends FlatSpec with Matchers {
   }
 
   it should "normalize a Vector" in {
+    implicit val tol = Kilometers(1e-15)
     val x = Kilometers(3)
     val y = Kilometers(4)
     val z = Kilometers(5)
     val normalized = QuantityVector(x, y, z).normalize(Kilometers)
-    normalized.magnitude should be(Kilometers(1.0))
+    normalized.magnitude =~ Kilometers(1.0) should be(right = true)
   }
 
   it should "add two Vectors" in {

--- a/src/test/scala/squants/electro/ElectroChecks.scala
+++ b/src/test/scala/squants/electro/ElectroChecks.scala
@@ -26,6 +26,7 @@ object ElectroChecks extends Properties("Electro") with QuantityChecks {
 
   implicit val tolCurrent = Amperes(tol)
   implicit val tolPotentional = Volts(tol)
+  implicit val tolEnergy = Joules(1e-12)
 
   property("Volts = Amps * Ohms (Ohm's Law)") = forAll(posNum, posNum) { (amps: TestData, ohms: TestData) ⇒
     Volts(amps * ohms) == Amperes(amps) * Ohms(ohms) &&
@@ -56,15 +57,15 @@ object ElectroChecks extends Properties("Electro") with QuantityChecks {
   }
 
   property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) ⇒
-    Joules(newtons * meters) == Newtons(newtons) * Meters(meters) &&
-      Joules(newtons * meters) == Meters(meters) * Newtons(newtons) &&
+    Joules(newtons * meters) =~ Newtons(newtons) * Meters(meters) &&
+      Joules(newtons * meters) =~ Meters(meters) * Newtons(newtons) &&
       Newtons(newtons).plusOrMinus(Newtons(tol)).contains(Joules(newtons * meters) / Meters(meters)) &&
       Meters(meters).plusOrMinus(Meters(tol)).contains(Joules(newtons * meters) / Newtons(newtons))
   }
 
   property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) ⇒
-    Joules(kilograms * grays) == Kilograms(kilograms) * Grays(grays) &&
-      Joules(kilograms * grays) == Grays(grays) * Kilograms(kilograms) &&
+    Joules(kilograms * grays) =~ Kilograms(kilograms) * Grays(grays) &&
+      Joules(kilograms * grays) =~ Grays(grays) * Kilograms(kilograms) &&
       Kilograms(kilograms).plusOrMinus(Kilograms(tol)).contains(Joules(kilograms * grays) / Grays(grays)) &&
       Grays(grays).plusOrMinus(Grays(tol)).contains(Joules(kilograms * grays) / Kilograms(kilograms))
   }

--- a/src/test/scala/squants/energy/EnergyChecks.scala
+++ b/src/test/scala/squants/energy/EnergyChecks.scala
@@ -25,9 +25,21 @@ import squants.QuantityChecks
  */
 object EnergyChecks extends Properties("Energy") with QuantityChecks {
 
+  override val tol = 1e-12
   override implicit val tolTime = Hours(tol)
   implicit val tolPower = Watts(tol)
   implicit val tolPowerRamp = WattsPerHour(tol)
+  implicit val tolEnergy = Joules(tol)
+  implicit val tolLength = Meters(tol)
+  implicit val tolForce = Newtons(tol)
+  implicit val tolSpecificEnergy = Grays(tol)
+  implicit val tolMass = Kilograms(tol)
+  implicit val tolEnergyDensity = JoulesPerCubicMeter(tol)
+  implicit val tolTemp = Kelvin(tol)
+  implicit val tolElectricCharge = Coulombs(tol)
+  implicit val tolVolume = CubicMeters(tol)
+  implicit val tolThermalCap = JoulesPerKelvin(tol)
+  implicit val tolElectricPotential = Volts(tol)
 
   property("WattHours = Watts * Hours") = forAll(posNum, posNum) { (watts: TestData, hours: TestData) ⇒
     WattHours(watts * hours) == Watts(watts) * Hours(hours) &&
@@ -51,37 +63,37 @@ object EnergyChecks extends Properties("Energy") with QuantityChecks {
   }
 
   property("Joules = Newtons * Meters") = forAll(posNum, posNum) { (newtons: TestData, meters: TestData) ⇒
-    Joules(newtons * meters) == Newtons(newtons) * Meters(meters) &&
-      Joules(newtons * meters) == Meters(meters) * Newtons(newtons) &&
-      Meters(meters).plusOrMinus(Meters(tol)).contains(Joules(newtons * meters) / Newtons(newtons)) &&
-      Newtons(newtons).plusOrMinus(Newtons(tol)).contains(Joules(newtons * meters) / Meters(meters))
+    Joules(newtons * meters) =~ (Newtons(newtons) * Meters(meters)) &&
+      Joules(newtons * meters) =~ (Meters(meters) * Newtons(newtons)) &&
+      Meters(meters) =~ (Joules(newtons * meters) / Newtons(newtons)) &&
+      Newtons(newtons) =~ (Joules(newtons * meters) / Meters(meters))
   }
 
   property("Joules = Kilograms * Grays") = forAll(posNum, posNum) { (kilograms: TestData, grays: TestData) ⇒
-    Joules(kilograms * grays) == Kilograms(kilograms) * Grays(grays) &&
-      Joules(kilograms * grays) == Grays(grays) * Kilograms(kilograms) &&
-      Grays(grays).plusOrMinus(Grays(tol)).contains(Joules(kilograms * grays) / Kilograms(kilograms)) &&
-      Kilograms(kilograms).plusOrMinus(Kilograms(tol)).contains(Joules(kilograms * grays) / Grays(grays))
+    Joules(kilograms * grays) =~ (Kilograms(kilograms) * Grays(grays)) &&
+      Joules(kilograms * grays) =~ (Grays(grays) * Kilograms(kilograms)) &&
+      Grays(grays) =~ (Joules(kilograms * grays) / Kilograms(kilograms)) &&
+      Kilograms(kilograms) =~ (Joules(kilograms * grays) / Grays(grays))
   }
 
   property("Joules = CubicMeters * JoulesPerCubicMeter") = forAll(posNum, posNum) { (cubicMeters: TestData, jpcm: TestData) ⇒
-    Joules(cubicMeters * jpcm) == CubicMeters(cubicMeters) * JoulesPerCubicMeter(jpcm) &&
-      Joules(cubicMeters * jpcm) == JoulesPerCubicMeter(jpcm) * CubicMeters(cubicMeters) &&
-      JoulesPerCubicMeter(jpcm).plusOrMinus(JoulesPerCubicMeter(tol)).contains(Joules(cubicMeters * jpcm) / CubicMeters(cubicMeters)) &&
-      CubicMeters(cubicMeters).plusOrMinus(CubicMeters(tol)).contains(Joules(cubicMeters * jpcm) / JoulesPerCubicMeter(jpcm))
+    Joules(cubicMeters * jpcm) =~ (CubicMeters(cubicMeters) * JoulesPerCubicMeter(jpcm)) &&
+      Joules(cubicMeters * jpcm) =~ (JoulesPerCubicMeter(jpcm) * CubicMeters(cubicMeters)) &&
+      JoulesPerCubicMeter(jpcm) =~ (Joules(cubicMeters * jpcm) / CubicMeters(cubicMeters)) &&
+      CubicMeters(cubicMeters) =~ (Joules(cubicMeters * jpcm) / JoulesPerCubicMeter(jpcm))
   }
 
   property("Joules = JoulesPerKelvin * Kelvin") = forAll(posNum, posNum) { (joulesPerKelvin: TestData, kelvin: TestData) ⇒
-    Joules(joulesPerKelvin * kelvin) == JoulesPerKelvin(joulesPerKelvin) * Kelvin(kelvin) &&
-      Joules(joulesPerKelvin * kelvin) == Kelvin(kelvin) * JoulesPerKelvin(joulesPerKelvin) &&
-      Kelvin(kelvin).plusOrMinus(Kelvin(tol)).contains(Joules(joulesPerKelvin * kelvin) / JoulesPerKelvin(joulesPerKelvin)) &&
-      JoulesPerKelvin(joulesPerKelvin).plusOrMinus(JoulesPerKelvin(tol)).contains(Joules(joulesPerKelvin * kelvin) / Kelvin(kelvin))
+    Joules(joulesPerKelvin * kelvin) =~ (JoulesPerKelvin(joulesPerKelvin) * Kelvin(kelvin)) &&
+      Joules(joulesPerKelvin * kelvin) =~ (Kelvin(kelvin) * JoulesPerKelvin(joulesPerKelvin)) &&
+      Kelvin(kelvin) =~ (Joules(joulesPerKelvin * kelvin) / JoulesPerKelvin(joulesPerKelvin)) &&
+      JoulesPerKelvin(joulesPerKelvin) =~ (Joules(joulesPerKelvin * kelvin) / Kelvin(kelvin))
   }
 
   property("Joules = Volt * Coulombs") = forAll(posNum, posNum) { (volts: TestData, coulombs: TestData) ⇒
-    Joules(volts * coulombs) == Volts(volts) * Coulombs(coulombs) &&
-      Joules(volts * coulombs) == Coulombs(coulombs) * Volts(volts) &&
-      Coulombs(coulombs).plusOrMinus(Coulombs(tol)).contains(Joules(volts * coulombs) / Volts(volts)) &&
-      Volts(volts).plusOrMinus(Volts(tol)).contains(Joules(volts * coulombs) / Coulombs(coulombs))
+    Joules(volts * coulombs) =~ (Volts(volts) * Coulombs(coulombs)) &&
+      Joules(volts * coulombs) =~ (Coulombs(coulombs) * Volts(volts)) &&
+      Coulombs(coulombs) =~ (Joules(volts * coulombs) / Volts(volts)) &&
+      Volts(volts) =~ (Joules(volts * coulombs) / Coulombs(coulombs))
   }
 }

--- a/src/test/scala/squants/energy/EnergySpec.scala
+++ b/src/test/scala/squants/energy/EnergySpec.scala
@@ -181,7 +181,7 @@ class EnergySpec extends FlatSpec with Matchers {
     terajoule should be(Terajoules(1))
 
     btu should be(BritishThermalUnits(1))
-    btuMultiplier should be(joule.value * 1055.05585262)
+    btuMultiplier should be(0.2930710701722222)
   }
 
   it should "provide implicit conversion from Double" in {

--- a/src/test/scala/squants/energy/SpecificEnergySpec.scala
+++ b/src/test/scala/squants/energy/SpecificEnergySpec.scala
@@ -52,14 +52,14 @@ class SpecificEnergySpec extends FlatSpec with Matchers {
   it should "provide aliases for single unit values" in {
     import SpecificEnergyConversions._
 
-    gray should be(SpecificEnergy(1))
+    gray should be(Grays(1))
   }
 
   it should "provide implicit conversion from Double" in {
     import SpecificEnergyConversions._
 
     val d = 10d
-    d.grays should be(SpecificEnergy(d))
+    d.grays should be(Grays(d))
   }
 
   it should "provide Numeric support" in {

--- a/src/test/scala/squants/experimental/UnitOfMeasureX.scala
+++ b/src/test/scala/squants/experimental/UnitOfMeasureX.scala
@@ -75,7 +75,7 @@ trait UnitOfMeasureX[A <: QuantityX[A]] extends Serializable {
 trait UnitConverterX { uom: UnitOfMeasureX[_] ⇒
 
   /**
-   * Defines a multiplier value relative to the Quantity's [[squants.ValueUnit]]
+   * Defines a multiplier value relative to the Quantity's [[squants.PrimaryUnit]]
    *
    * @return
    */

--- a/src/test/scala/squants/experimental/json/MoneySerializer.scala
+++ b/src/test/scala/squants/experimental/json/MoneySerializer.scala
@@ -6,7 +6,7 @@
 **                                                                      **
 \*                                                                      */
 
-package squants.json
+package squants.experimental.json
 
 import org.json4s.{ Formats, Serializer }
 import squants.market.Money
@@ -43,7 +43,7 @@ class MoneySerializer extends Serializer[Money] {
       JObject(
         List(
           "amount" -> JDecimal(money.amount),
-          "currency" -> JString(money.valueUnit.code)))
+          "currency" -> JString(money.unit.code)))
   }
 }
 

--- a/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
+++ b/src/test/scala/squants/experimental/json/QuantitySerializerSpec.scala
@@ -6,7 +6,7 @@
 **                                                                      **
 \*                                                                      */
 
-package squants.json
+package squants.experimental.json
 
 import org.scalatest._
 import org.json4s.DefaultFormats
@@ -21,13 +21,13 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
 
   object QuantitySerializerMarshaller {
     implicit val formats = DefaultFormats.withBigDecimal +
-      new PowerSerializer(Kilowatts) +
-      new EnergyPriceSerializer(MegawattHours) +
-      new MassPriceSerializer(Pounds) +
+      new PowerSerializer +
+      new EnergyPriceSerializer +
+      new MassPriceSerializer +
       new MoneySerializer +
-      new TimeSerializer(Seconds) +
-      new MassSerializer(Pounds) +
-      new TimePriceSerializer(Hours)
+      new TimeSerializer +
+      new MassSerializer +
+      new TimePriceSerializer
   }
 
   behavior of "QuantitySerializer"
@@ -37,37 +37,31 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
   val seedValue = 10.22
   val seedValueInt = 10
   val jsonkW = "{\"value\":10.22,\"unit\":\"kW\"}"
-  val jsonMWin = "{\"value\":10.22,\"unit\":\"MW\"}"
-  val jsonMWout = "{\"value\":10220.0,\"unit\":\"kW\"}"
-  val jsonGWin = "{\"value\":10.22,\"unit\":\"GW\"}"
-  val jsonGWout = "{\"value\":1.022E+7,\"unit\":\"kW\"}"
+  val jsonMW = "{\"value\":10.22,\"unit\":\"MW\"}"
+  val jsonGW = "{\"value\":10.22,\"unit\":\"GW\"}"
   val jsonPowerInt = "{\"value\":10,\"unit\":\"kW\"}"
 
-  val jsonMillisIn = "{\"value\":10.22,\"unit\":\"ms\"}"
-  val jsonMillisOut = "{\"value\":0.01022,\"unit\":\"s\"}"
-  val jsonSecondsIn = "{\"value\":10.22,\"unit\":\"s\"}"
-  val jsonSecondsOut = "{\"value\":10.22,\"unit\":\"s\"}"
-  val jsonMinutesIn = "{\"value\":10.22,\"unit\":\"m\"}"
-  val jsonMinutesOut = "{\"value\":613.2,\"unit\":\"s\"}"
-  val jsonHoursIn = "{\"value\":10.22,\"unit\":\"h\"}"
-  val jsonHoursOut = "{\"value\":36792.0,\"unit\":\"s\"}"
+  val jsonMillis = "{\"value\":10.22,\"unit\":\"ms\"}"
+  val jsonSeconds = "{\"value\":10.22,\"unit\":\"s\"}"
+  val jsonMinutes = "{\"value\":10.22,\"unit\":\"m\"}"
+  val jsonHours = "{\"value\":10.22,\"unit\":\"h\"}"
   val jsonTimeInt = "{\"value\":10,\"unit\":\"s\"}"
 
   it must "serialize a Power value" in {
     val json = write[Power](Kilowatts(seedValue))
     json must be(jsonkW)
     val json2 = write[Power](Megawatts(seedValue))
-    json2 must be(jsonMWout)
+    json2 must be(jsonMW)
     val json3 = write[Power](Gigawatts(seedValue))
-    json3 must be(jsonGWout)
+    json3 must be(jsonGW)
   }
 
   it must "deserialize a Power value" in {
     val power = read[Power](jsonkW)
     power must be(Kilowatts(seedValue))
-    val powerMW = read[Power](jsonMWin)
+    val powerMW = read[Power](jsonMW)
     powerMW must be(Megawatts(seedValue))
-    val powerGW = read[Power](jsonGWin)
+    val powerGW = read[Power](jsonGW)
     powerGW must be(Gigawatts(seedValue))
     val powerInt = read[Power](jsonPowerInt)
     powerInt must be(Kilowatts(seedValueInt))
@@ -75,23 +69,23 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
 
   it must "serialize a Time value" in {
     val json = write[Time](Milliseconds(seedValue))
-    json must be(jsonMillisOut)
+    json must be(jsonMillis)
     val json2 = write[Time](Seconds(seedValue))
-    json2 must be(jsonSecondsOut)
+    json2 must be(jsonSeconds)
     val json3 = write[Time](Minutes(seedValue))
-    json3 must be(jsonMinutesOut)
+    json3 must be(jsonMinutes)
     val json4 = write[Time](Hours(seedValue))
-    json4 must be(jsonHoursOut)
+    json4 must be(jsonHours)
   }
 
   it must "deserialize a Time value" in {
-    val time = read[Time](jsonMillisIn)
+    val time = read[Time](jsonMillis)
     time must be(Milliseconds(seedValue))
-    val time2 = read[Time](jsonSecondsIn)
+    val time2 = read[Time](jsonSeconds)
     time2 must be(Seconds(seedValue))
-    val time3 = read[Time](jsonMinutesIn)
+    val time3 = read[Time](jsonMinutes)
     time3 must be(Minutes(seedValue))
-    val time4 = read[Time](jsonHoursIn)
+    val time4 = read[Time](jsonHours)
     time4 must be(Hours(seedValue))
     val time5 = read[Time](jsonTimeInt)
     time5 must be(Seconds(seedValueInt))
@@ -119,7 +113,7 @@ class QuantitySerializerSpec extends FlatSpec with MustMatchers {
 
   val jsonEnergyPrice = "{\"amount\":10.22,\"currency\":\"USD\",\"per\":\"1.0 MWh\"}"
   val jsonMassPrice = "{\"amount\":10.22,\"currency\":\"USD\",\"per\":\"1.0 lb\"}"
-  val jsonTimePrice = "{\"amount\":10.22,\"currency\":\"USD\",\"per\":\"0.5 h\"}"
+  val jsonTimePrice = "{\"amount\":10.22,\"currency\":\"USD\",\"per\":\"30.0 m\"}"
 
   it must "serialize an Energy Price" in {
     val json = write[Price[Energy]](USD(seedValue) / MegawattHours(1))

--- a/src/test/scala/squants/space/VolumeSpec.scala
+++ b/src/test/scala/squants/space/VolumeSpec.scala
@@ -35,7 +35,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     Decilitres(1).toDecilitres should be(1)
     Hectolitres(1).toHectolitres should be(1)
 
-    CubicMiles(1).toCubicMiles should be(1)
+    CubicUsMiles(1).toCubicMiles should be(1)
     CubicYards(1).toCubicYards should be(1)
     CubicFeet(1).toCubicFeet should be(1)
     CubicInches(1).toCubicInches should be(1)
@@ -59,7 +59,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     Volume("10.22 cl").get should be(Centilitres(10.22))
     Volume("10.22 dl").get should be(Decilitres(10.22))
     Volume("10.22 hl").get should be(Hectolitres(10.22))
-    Volume("10.22 mi³").get should be(CubicMiles(10.22))
+    Volume("10.22 mi³").get should be(CubicUsMiles(10.22))
     Volume("10.22 yd³").get should be(CubicYards(10.22))
     Volume("10.22 ft³").get should be(CubicFeet(10.22))
     Volume("10.22 in³").get should be(CubicInches(10.22))
@@ -123,7 +123,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     Decilitres(1).toString(Decilitres) should be("1.0 dl")
     Hectolitres(1).toString(Hectolitres) should be("1.0 hl")
 
-    CubicMiles(1).toString(CubicMiles) should be("1.0 mi³")
+    CubicUsMiles(1).toString(CubicUsMiles) should be("1.0 mi³")
     CubicYards(1).toString(CubicYards) should be("1.0 yd³")
     CubicFeet(1).toString(CubicFeet) should be("1.0 ft³")
     CubicInches(1).toString(CubicInches) should be("1.0 in³")
@@ -178,7 +178,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     hectoliter should be(Hectolitres(1))
     hectolitre should be(Hectolitres(1))
 
-    cubicMile should be(CubicMiles(1))
+    cubicMile should be(CubicUsMiles(1))
     cubicYard should be(CubicYards(1))
     cubicFoot should be(CubicFeet(1))
     cubicInch should be(CubicInches(1))
@@ -213,7 +213,7 @@ class VolumeSpec extends FlatSpec with Matchers {
     d.hectoliters should be(Hectolitres(d))
     d.hectolitres should be(Hectolitres(d))
 
-    d.cubicMiles should be(CubicMiles(d))
+    d.cubicMiles should be(CubicUsMiles(d))
     d.cubicYards should be(CubicYards(d))
     d.cubicFeet should be(CubicFeet(d))
     d.cubicInches should be(CubicInches(d))

--- a/src/test/scala/squants/thermal/ThermalChecks.scala
+++ b/src/test/scala/squants/thermal/ThermalChecks.scala
@@ -48,10 +48,11 @@ object ThermalChecks extends Properties("Thermal") with QuantityChecks {
 
     implicit val tempTol = Kelvin(tol)
     implicit val thermTol = JoulesPerKelvin(tol)
+    implicit val energyTol = Joules(1e-12)
 
-    JoulesPerKelvin(thermCap) * Kelvin(temp) == Joules(thermCap * temp) &&
-      Kelvin(temp) * JoulesPerKelvin(thermCap) == Joules(thermCap * temp) &&
-      Joules(thermCap * temp) / JoulesPerKelvin(thermCap) =~ Kelvin(temp) &&
-      Joules(thermCap * temp) / Kelvin(temp) =~ JoulesPerKelvin(thermCap)
+    Joules(thermCap * temp) =~ JoulesPerKelvin(thermCap) * Kelvin(temp) &&
+      Joules(thermCap * temp) =~ Kelvin(temp) * JoulesPerKelvin(thermCap) &&
+      Kelvin(temp) =~ Joules(thermCap * temp) / JoulesPerKelvin(thermCap) &&
+      JoulesPerKelvin(thermCap) =~ Joules(thermCap * temp) / Kelvin(temp)
   }
 }


### PR DESCRIPTION
Rename Quantity.valueUnit to Quantity.unit

Rename QuantityCompanion to Dimension
Add dimension property Quantity
Enhance UOM model to include primary and SI units

Normalize Temperature model

Simplify Serializers
Remove redundant toString methods

Update Length/Area/Volume operations to be unit-sensitive
Rename CubicMiles to CubicUsMiles