### PR TITLE
Addition of unit KilometersPerSecond to Velocity.

### DIFF
--- a/shared/src/main/scala/squants/motion/Velocity.scala
+++ b/shared/src/main/scala/squants/motion/Velocity.scala
@@ -41,6 +41,7 @@ final class Velocity private (val value: Double, val unit: VelocityUnit)
 
   def toFeetPerSecond = to(FeetPerSecond)
   def toMetersPerSecond = to(MetersPerSecond)
+  def toKilometersPerSecond = to(KilometersPerSecond)
   def toKilometersPerHour = to(KilometersPerHour)
   def toUsMilesPerHour = to(UsMilesPerHour)
   def toInternationalMilesPerHour = to(InternationalMilesPerHour)
@@ -54,7 +55,7 @@ object Velocity extends Dimension[Velocity] {
   def name = "Velocity"
   def primaryUnit = MetersPerSecond
   def siUnit = MetersPerSecond
-  def units = Set(MetersPerSecond, FeetPerSecond, KilometersPerHour, UsMilesPerHour,
+  def units = Set(MetersPerSecond, FeetPerSecond, KilometersPerSecond, KilometersPerHour, UsMilesPerHour,
     InternationalMilesPerHour, Knots)
 }
 
@@ -71,8 +72,13 @@ object MetersPerSecond extends VelocityUnit with PrimaryUnit with SiUnit {
   val symbol = "m/s"
 }
 
-object KilometersPerHour extends VelocityUnit {
+object KilometersPerSecond extends VelocityUnit {
   val symbol = "km/s"
+  val conversionFactor = Kilometers.conversionFactor / Meters.conversionFactor
+}
+
+object KilometersPerHour extends VelocityUnit {
+  val symbol = "km/h"
   val conversionFactor = (Kilometers.conversionFactor / Meters.conversionFactor) / Time.SecondsPerHour
 }
 
@@ -94,13 +100,15 @@ object Knots extends VelocityUnit {
 object VelocityConversions {
   lazy val footPerSecond = FeetPerSecond(1)
   lazy val meterPerSecond = MetersPerSecond(1)
-  lazy val kilometerPerSecond = KilogramsPerSecond(1)
+  lazy val kilometerPerSecond = KilometersPerSecond(1)
+  lazy val kilometerPerHour = KilometersPerHour(1)
   lazy val milePerHour = UsMilesPerHour(1)
   lazy val knot = Knots(1)
 
   implicit class VelocityConversions[A](n: A)(implicit num: Numeric[A]) {
     def fps = FeetPerSecond(n)
     def mps = MetersPerSecond(n)
+    def kps = KilometersPerSecond(n)
     def kph = KilometersPerHour(n)
     def mph = UsMilesPerHour(n)
     def knots = Knots(n)

--- a/shared/src/test/scala/squants/motion/VelocitySpec.scala
+++ b/shared/src/test/scala/squants/motion/VelocitySpec.scala
@@ -27,6 +27,7 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "create values using UOM factories" in {
     MetersPerSecond(1).toMetersPerSecond should be(1)
     FeetPerSecond(1).toFeetPerSecond should be(1)
+    KilometersPerSecond(1).toKilometersPerSecond should be(1)
     KilometersPerHour(1).toKilometersPerHour should be(1)
     UsMilesPerHour(1).toUsMilesPerHour should be(1)
     InternationalMilesPerHour(1).toInternationalMilesPerHour should be(1)
@@ -35,7 +36,8 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "create values from properly formatted Strings" in {
     Velocity("10.22 m/s").get should be(MetersPerSecond(10.22))
     Velocity("10.22 ft/s").get should be(FeetPerSecond(10.22))
-    Velocity("10.22 km/s").get should be(KilometersPerHour(10.22))
+    Velocity("10.22 km/s").get should be(KilometersPerSecond(10.22))
+    Velocity("10.22 km/h").get should be(KilometersPerHour(10.22))
     Velocity("10.22 mph").get should be(UsMilesPerHour(10.22))
     Velocity("10.22 zz").failed.get should be(QuantityParseException("Unable to parse Velocity", "10.22 zz"))
     Velocity("zz m/s").failed.get should be(QuantityParseException("Unable to parse Velocity", "zz m/s"))
@@ -55,7 +57,8 @@ class VelocitySpec extends FlatSpec with Matchers {
   it should "return properly formatted strings for all supported Units of Measure" in {
     MetersPerSecond(1).toString(MetersPerSecond) should be("1.0 m/s")
     FeetPerSecond(1).toString(FeetPerSecond) should be("1.0 ft/s")
-    KilometersPerHour(1).toString(KilometersPerHour) should be("1.0 km/s")
+    KilometersPerSecond(1).toString(KilometersPerSecond) should be("1.0 km/s")
+    KilometersPerHour(1).toString(KilometersPerHour) should be("1.0 km/h")
     UsMilesPerHour(1).toString(UsMilesPerHour) should be("1.0 mph")
     InternationalMilesPerHour(1).toString(InternationalMilesPerHour) should be("1.0 imph")
     Knots(1).toString(Knots) should be("1.0 kn")
@@ -84,7 +87,8 @@ class VelocitySpec extends FlatSpec with Matchers {
 
     meterPerSecond should be(MetersPerSecond(1))
     footPerSecond should be(FeetPerSecond(1))
-    kilometerPerSecond should be(KilogramsPerSecond(1))
+    kilometerPerSecond should be(KilometersPerSecond(1))
+    kilometerPerHour should be(KilometersPerHour(1))
     milePerHour should be(UsMilesPerHour(1))
     knot should be(Knots(1))
   }
@@ -95,6 +99,7 @@ class VelocitySpec extends FlatSpec with Matchers {
     val d = 10d
     d.fps should be(FeetPerSecond(d))
     d.mps should be(MetersPerSecond(d))
+    d.kps should be(KilometersPerSecond(d))
     d.kph should be(KilometersPerHour(d))
     d.mph should be(UsMilesPerHour(d))
     d.knots should be(Knots(d))


### PR DESCRIPTION
I am working for [Gemini Observatory](http://www.gemini.edu) and we are in the process of adopting squants for parts of our [Observatory Control System](https://github.com/gemini-hlsw/ocs) to gain additional type safety and to be able to represent and persist user inputs as values with a specific unit (as chosen by the users). Thank you very much for your work!

Dealing with speeds I was 
* missing a unit to represent kilometers per second,
* noted that the symbol for kilometers per hour is "km/s" instead of "km/h" and
* noted that `kilometerPerSecond` in `VelocityConversions` is defined as `KilogramsPerSecond(1)`.

Here is a PR for your consideration that contains a change to the symbol for kilometers per hour, changes the definition of `kilometerPerSecond` and adds a unit for kilometers per second.