### PR TITLE
Allow numbers with exponential notation when parsing a Dimension.

### DIFF
--- a/shared/src/main/scala/squants/Dimension.scala
+++ b/shared/src/main/scala/squants/Dimension.scala
@@ -66,7 +66,7 @@ trait Dimension[A <: Quantity[A]] {
       case _                             ⇒ Failure(QuantityParseException(s"Unable to parse $name", s))
     }
   }
-  private lazy val QuantityString = ("^([-+]?[0-9]*\\.?[0-9]+) *(" + units.map { u: UnitOfMeasure[A] ⇒ u.symbol }.reduceLeft(_ + "|" + _) + ")$").r
+  private lazy val QuantityString = ("^([-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?) *(" + units.map { u: UnitOfMeasure[A] ⇒ u.symbol }.reduceLeft(_ + "|" + _) + ")$").r
 
   private def parseTuple(value: Double, symbol: String): Try[A] = {
     symbolToUnit(symbol) match {

--- a/shared/src/test/scala/squants/QuantitySpec.scala
+++ b/shared/src/test/scala/squants/QuantitySpec.scala
@@ -81,7 +81,18 @@ class QuantitySpec extends FlatSpec with Matchers {
   }
 
   it should "create values from properly formatted Strings" in {
+    Thingee("42 th").get should be(Thangs(42))
     Thingee("10.22 th").get should be(Thangs(10.22))
+    Thingee("1e5 th").get should be(Thangs(1e5))
+    Thingee("1E5 th").get should be(Thangs(1E5))
+    Thingee("1e+5 th").get should be(Thangs(1e+5))
+    Thingee("1e-5 th").get should be(Thangs(1e-5))
+    Thingee("1.0e5 th").get should be(Thangs(1.0e5))
+    Thingee("1.0E5 th").get should be(Thangs(1.0E5))
+    Thingee("1.0e+5 th").get should be(Thangs(1.0e+5))
+    Thingee("1.01E+5 th").get should be(Thangs(1.01E+5))
+    Thingee("1.012e-5 th").get should be(Thangs(1.012e-5))
+    Thingee("12.0123E-5 th").get should be(Thangs(12.0123E-5))
     Thingee("10.22 kth").get should be(Kilothangs(10.22))
   }
 


### PR DESCRIPTION
I noticed that currently the parsing of `Dimension`s does not support exponential notation like e.g. `5.0e-17` etc. Executing `Velocity("2.0e3 m/s")` for example will fail.

Here is a PR for your consideration that contains a change to the regular expression used when splitting a string into the number and units part and a few additional tests.