### PR TITLE
Add Angstroms to Length.

### DIFF
--- a/shared/src/main/scala/squants/space/Length.scala
+++ b/shared/src/main/scala/squants/space/Length.scala
@@ -62,6 +62,7 @@ final class Length private (val value: Double, val unit: LengthUnit)
   def squared = this * this
   def cubed = this * this * this
 
+  def toAngstroms = to(Angstroms)
   def toNanometers = to(Nanometers)
   def toMicrons = to(Microns)
   def toMillimeters = to(Millimeters)
@@ -90,7 +91,7 @@ object Length extends Dimension[Length] with BaseDimension {
   def name = "Length"
   def primaryUnit = Meters
   def siUnit = Meters
-  def units = Set(Nanometers, Microns, Millimeters, Centimeters,
+  def units = Set(Angstroms, Nanometers, Microns, Millimeters, Centimeters,
     Decimeters, Meters, Decameters, Hectometers, Kilometers,
     Inches, Feet, Yards, UsMiles, InternationalMiles, NauticalMiles,
     AstronomicalUnits, LightYears)
@@ -102,6 +103,13 @@ object Length extends Dimension[Length] with BaseDimension {
  */
 trait LengthUnit extends UnitOfMeasure[Length] with UnitConverter {
   def apply[A](n: A)(implicit num: Numeric[A]) = Length(n, this)
+}
+
+object Angstroms extends LengthUnit {
+  // note: the symbol used here is the letter "\u00C5" which is to be preferred over the angstrom sign "\u212B"
+  // see also: https://en.wikipedia.org/wiki/Å and http://www.fileformat.info/info/unicode/char/00c5/index.htm
+  val symbol = "Å"
+  val conversionFactor = 100 * MetricSystem.Pico
 }
 
 object Nanometers extends LengthUnit {
@@ -189,6 +197,7 @@ object LightYears extends LengthUnit {
 }
 
 object LengthConversions {
+  lazy val angstrom = Angstroms(1)
   lazy val nanometer = Nanometers(1)
   lazy val nanometre = Nanometers(1)
   lazy val micron = Microns(1)
@@ -217,6 +226,8 @@ object LengthConversions {
   lazy val lightYear = LightYears(1)
 
   implicit class LengthConversions[A](n: A)(implicit num: Numeric[A]) {
+    def Å = Angstroms(n)
+    def angstroms = Angstroms(n)
     def nm = Nanometers(n)
     def nanometers = Nanometers(n)
     def nanometres = Nanometers(n)

--- a/shared/src/test/scala/squants/space/LengthSpec.scala
+++ b/shared/src/test/scala/squants/space/LengthSpec.scala
@@ -27,6 +27,7 @@ class LengthSpec extends FlatSpec with Matchers {
   it should "create values using UOM factories" in {
 
     Meters(1).toMeters should be(1)
+    Angstroms(1).toAngstroms should be (1)
     Nanometers(1).toNanometers should be(1)
     Microns(1).toMicrons should be(1)
     Millimeters(1).toMillimeters should be(1)
@@ -47,6 +48,7 @@ class LengthSpec extends FlatSpec with Matchers {
   }
 
   it should "create values from properly formatted Strings" in {
+    Length("10.33 Å").get should be(Angstroms(10.33))
     Length("10.33 nm").get should be(Nanometers(10.33))
     Length("10.33 µm").get should be(Microns(10.33))
     Length("10.33 mm").get should be(Millimeters(10.33))
@@ -71,6 +73,7 @@ class LengthSpec extends FlatSpec with Matchers {
   it should "properly convert to all supported Units of Measure" in {
     val x = Meters(1)
     x.toMeters should be(1)
+    x.toAngstroms should be(1 / (100*MetricSystem.Pico))
     x.toNanometers should be(1 / MetricSystem.Nano)
     x.toMicrons should be(1 / MetricSystem.Micro)
     x.toMillimeters should be(1 / MetricSystem.Milli)
@@ -93,6 +96,7 @@ class LengthSpec extends FlatSpec with Matchers {
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     Meters(1).toString(Meters) should be("1.0 m")
+    Angstroms(1).toString(Angstroms) should be ("1.0 Å")
     Nanometers(1).toString(Nanometers) should be("1.0 nm")
     Microns(1).toString(Microns) should be("1.0 µm")
     Millimeters(1).toString(Millimeters) should be("1.0 mm")
@@ -153,6 +157,7 @@ class LengthSpec extends FlatSpec with Matchers {
   it should "provide aliases for single unit values" in {
     import LengthConversions._
 
+    angstrom should be(Angstroms(1))
     nanometer should be(Nanometers(1))
     nanometre should be(Nanometers(1))
     micron should be(Microns(1))
@@ -185,6 +190,8 @@ class LengthSpec extends FlatSpec with Matchers {
     import LengthConversions._
 
     val d = 10d
+    d.Å should be(Angstroms(d))
+    d.angstroms should be(Angstroms(d))
     d.nm should be(Nanometers(d))
     d.nanometers should be(Nanometers(d))
     d.nanometres should be(Nanometers(d))
@@ -219,6 +226,7 @@ class LengthSpec extends FlatSpec with Matchers {
   it should "provide implicit conversion from String" in {
     import LengthConversions._
 
+    "10.33 Å".toLength.get should be(Angstroms(10.33))
     "10.33 nm".toLength.get should be(Nanometers(10.33))
     "10.33 µm".toLength.get should be(Microns(10.33))
     "10.33 mm".toLength.get should be(Millimeters(10.33))


### PR DESCRIPTION
Addition of the [Angstrom](https://en.wikipedia.org/wiki/Angstrom) to the available units for `Length`. The  angstrom is a unit of length equal to 10e−10 m (one ten-billionth of a meter) or 100 pm.