### PR TITLE
Fixes to AreaDensity

### DIFF
--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -24,8 +24,8 @@ final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
   def *(that: Area): Mass = Kilograms(toKilogramsPerSquareMeter * that.toSquareMeters)
 
   def toKilogramsPerSquareMeter = to(KilogramsPerSquareMeter)
-	def toGramsPerSquareCentimeter = to(GramsPerSquareCentimeter)
-	def toKilogramsPerHectare = to(KilogramsPerHectare)
+  def toGramsPerSquareCentimeter = to(GramsPerSquareCentimeter)
+  def toKilogramsPerHectare = to(KilogramsPerHectare)
 }
 
 /**
@@ -50,24 +50,24 @@ object KilogramsPerSquareMeter extends AreaDensityUnit with PrimaryUnit with SiU
 }
 
 object KilogramsPerHectare extends AreaDensityUnit with UnitConverter {
-	val symbol = "kg/hectare"
-	val conversionFactor = 1/(100*100d)
+  val symbol = "kg/hectare"
+  val conversionFactor = 1/(100*100d)
 }
 
 object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter {
-	val symbol = "g/cm²"
-	val conversionFactor = (100*100d)/1000d
+  val symbol = "g/cm²"
+  val conversionFactor = (100*100d)/1000d
 }
 
 object AreaDensityConversions {
   lazy val kilogramPerSquareMeter = KilogramsPerSquareMeter(1)
-	lazy val kilogramPerHectare = KilogramsPerHectare(1)
-	lazy val gramPerSquareCentimeter = GramsPerSquareCentimeter(1)
+  lazy val kilogramPerHectare = KilogramsPerHectare(1)
+  lazy val gramPerSquareCentimeter = GramsPerSquareCentimeter(1)
 
   implicit class AreaDensityConversions[A](n: A)(implicit num: Numeric[A]) {
     def kilogramsPerSquareMeter = KilogramsPerSquareMeter(n)
-	  def kilogramsPerHectare = KilogramsPerHectare(n)
-	  def gramsPerSquareCentimeter = GramsPerSquareCentimeter(n)
+    def kilogramsPerHectare = KilogramsPerHectare(n)
+    def gramsPerSquareCentimeter = GramsPerSquareCentimeter(n)
   }
 
   implicit object AreaDensityNumeric extends AbstractQuantityNumeric[AreaDensity](AreaDensity.primaryUnit)

--- a/shared/src/main/scala/squants/mass/AreaDensity.scala
+++ b/shared/src/main/scala/squants/mass/AreaDensity.scala
@@ -21,9 +21,11 @@ final class AreaDensity private (val value: Double, val unit: AreaDensityUnit)
 
   def dimension = AreaDensity
 
-  def *(that: Area): Mass = Kilograms(value * that.toSquareMeters)
+  def *(that: Area): Mass = Kilograms(toKilogramsPerSquareMeter * that.toSquareMeters)
 
   def toKilogramsPerSquareMeter = to(KilogramsPerSquareMeter)
+	def toGramsPerSquareCentimeter = to(GramsPerSquareCentimeter)
+	def toKilogramsPerHectare = to(KilogramsPerHectare)
 }
 
 /**
@@ -36,7 +38,7 @@ object AreaDensity extends Dimension[AreaDensity] {
   def name = "AreaDensity"
   def primaryUnit = KilogramsPerSquareMeter
   def siUnit = KilogramsPerSquareMeter
-  def units = Set(KilogramsPerSquareMeter)
+  def units = Set(KilogramsPerSquareMeter, KilogramsPerHectare, GramsPerSquareCentimeter)
 }
 
 trait AreaDensityUnit extends UnitOfMeasure[AreaDensity] {
@@ -47,11 +49,25 @@ object KilogramsPerSquareMeter extends AreaDensityUnit with PrimaryUnit with SiU
   val symbol = "kg/m²"
 }
 
+object KilogramsPerHectare extends AreaDensityUnit with UnitConverter {
+	val symbol = "kg/hectare"
+	val conversionFactor = 1/(100*100d)
+}
+
+object GramsPerSquareCentimeter extends AreaDensityUnit with UnitConverter {
+	val symbol = "g/cm²"
+	val conversionFactor = (100*100d)/1000d
+}
+
 object AreaDensityConversions {
   lazy val kilogramPerSquareMeter = KilogramsPerSquareMeter(1)
+	lazy val kilogramPerHectare = KilogramsPerHectare(1)
+	lazy val gramPerSquareCentimeter = GramsPerSquareCentimeter(1)
 
   implicit class AreaDensityConversions[A](n: A)(implicit num: Numeric[A]) {
     def kilogramsPerSquareMeter = KilogramsPerSquareMeter(n)
+	  def kilogramsPerHectare = KilogramsPerHectare(n)
+	  def gramsPerSquareCentimeter = GramsPerSquareCentimeter(n)
   }
 
   implicit object AreaDensityNumeric extends AbstractQuantityNumeric[AreaDensity](AreaDensity.primaryUnit)

--- a/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
@@ -10,7 +10,7 @@ package squants.mass
 
 import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
-import squants.space.SquareMeters
+import squants.space.{Hectares, SquareMeters}
 
 import scala.language.postfixOps
 
@@ -25,25 +25,35 @@ class AreaDensitySpec extends FlatSpec with Matchers {
 
   it should "create values using UOM factories" in {
     KilogramsPerSquareMeter(1).toKilogramsPerSquareMeter should be(1)
+	  KilogramsPerHectare(1).toKilogramsPerHectare should be(1)
+	  GramsPerSquareCentimeter(1).toGramsPerSquareCentimeter should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
     AreaDensity("10.22 kg/m²").get should be(KilogramsPerSquareMeter(10.22))
     AreaDensity("10.45 zz").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "10.45 zz"))
     AreaDensity("zz kg/m²").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "zz kg/m²"))
+	  AreaDensity("10.33 kg/hectare").get should be(KilogramsPerHectare(10.33))
+	  AreaDensity("10.19 g/cm²").get should be(GramsPerSquareCentimeter(10.19))
   }
 
   it should "properly convert to all supported Units of Measure" in {
     val x = KilogramsPerSquareMeter(1)
     x.toKilogramsPerSquareMeter should be(1)
+	  x.toKilogramsPerHectare should be(1e4)
+	  x.toGramsPerSquareCentimeter should be(0.1)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     KilogramsPerSquareMeter(1).toString should be("1.0 kg/m²")
+	  KilogramsPerHectare(1).toString should be("1.0 kg/hectare")
+	  GramsPerSquareCentimeter(1).toString should be("1.0 g/cm²")
   }
 
   it should "return Mass when multiplied by Volume" in {
     KilogramsPerSquareMeter(1) * SquareMeters(1) should be(Kilograms(1))
+	  KilogramsPerHectare(1) * Hectares(1) should be(Kilograms(1))
+	  GramsPerSquareCentimeter(1000) * SquareMeters(1e-4) should be(Kilograms(1))
   }
 
   behavior of "AreaDensityConversion"
@@ -52,6 +62,8 @@ class AreaDensitySpec extends FlatSpec with Matchers {
     import AreaDensityConversions._
 
     kilogramPerSquareMeter should be(KilogramsPerSquareMeter(1))
+	  kilogramPerHectare should be(KilogramsPerHectare(1))
+	  gramPerSquareCentimeter should be(GramsPerSquareCentimeter(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -59,6 +71,8 @@ class AreaDensitySpec extends FlatSpec with Matchers {
 
     val d = 10.22d
     d.kilogramsPerSquareMeter should be(KilogramsPerSquareMeter(d))
+	  d.kilogramsPerHectare should be(KilogramsPerHectare(d))
+	  d.gramsPerSquareCentimeter should be(GramsPerSquareCentimeter(d))
   }
 
   it should "provide Numeric support" in {

--- a/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
+++ b/shared/src/test/scala/squants/mass/AreaDensitySpec.scala
@@ -25,35 +25,35 @@ class AreaDensitySpec extends FlatSpec with Matchers {
 
   it should "create values using UOM factories" in {
     KilogramsPerSquareMeter(1).toKilogramsPerSquareMeter should be(1)
-	  KilogramsPerHectare(1).toKilogramsPerHectare should be(1)
-	  GramsPerSquareCentimeter(1).toGramsPerSquareCentimeter should be(1)
+    KilogramsPerHectare(1).toKilogramsPerHectare should be(1)
+    GramsPerSquareCentimeter(1).toGramsPerSquareCentimeter should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
     AreaDensity("10.22 kg/m²").get should be(KilogramsPerSquareMeter(10.22))
     AreaDensity("10.45 zz").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "10.45 zz"))
     AreaDensity("zz kg/m²").failed.get should be(QuantityParseException("Unable to parse AreaDensity", "zz kg/m²"))
-	  AreaDensity("10.33 kg/hectare").get should be(KilogramsPerHectare(10.33))
-	  AreaDensity("10.19 g/cm²").get should be(GramsPerSquareCentimeter(10.19))
+    AreaDensity("10.33 kg/hectare").get should be(KilogramsPerHectare(10.33))
+    AreaDensity("10.19 g/cm²").get should be(GramsPerSquareCentimeter(10.19))
   }
 
   it should "properly convert to all supported Units of Measure" in {
     val x = KilogramsPerSquareMeter(1)
     x.toKilogramsPerSquareMeter should be(1)
-	  x.toKilogramsPerHectare should be(1e4)
-	  x.toGramsPerSquareCentimeter should be(0.1)
+    x.toKilogramsPerHectare should be(1e4)
+    x.toGramsPerSquareCentimeter should be(0.1)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     KilogramsPerSquareMeter(1).toString should be("1.0 kg/m²")
-	  KilogramsPerHectare(1).toString should be("1.0 kg/hectare")
-	  GramsPerSquareCentimeter(1).toString should be("1.0 g/cm²")
+    KilogramsPerHectare(1).toString should be("1.0 kg/hectare")
+    GramsPerSquareCentimeter(1).toString should be("1.0 g/cm²")
   }
 
   it should "return Mass when multiplied by Volume" in {
     KilogramsPerSquareMeter(1) * SquareMeters(1) should be(Kilograms(1))
-	  KilogramsPerHectare(1) * Hectares(1) should be(Kilograms(1))
-	  GramsPerSquareCentimeter(1000) * SquareMeters(1e-4) should be(Kilograms(1))
+    KilogramsPerHectare(1) * Hectares(1) should be(Kilograms(1))
+    GramsPerSquareCentimeter(1000) * SquareMeters(1e-4) should be(Kilograms(1))
   }
 
   behavior of "AreaDensityConversion"
@@ -62,8 +62,8 @@ class AreaDensitySpec extends FlatSpec with Matchers {
     import AreaDensityConversions._
 
     kilogramPerSquareMeter should be(KilogramsPerSquareMeter(1))
-	  kilogramPerHectare should be(KilogramsPerHectare(1))
-	  gramPerSquareCentimeter should be(GramsPerSquareCentimeter(1))
+    kilogramPerHectare should be(KilogramsPerHectare(1))
+    gramPerSquareCentimeter should be(GramsPerSquareCentimeter(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -71,8 +71,8 @@ class AreaDensitySpec extends FlatSpec with Matchers {
 
     val d = 10.22d
     d.kilogramsPerSquareMeter should be(KilogramsPerSquareMeter(d))
-	  d.kilogramsPerHectare should be(KilogramsPerHectare(d))
-	  d.gramsPerSquareCentimeter should be(GramsPerSquareCentimeter(d))
+    d.kilogramsPerHectare should be(KilogramsPerHectare(d))
+    d.gramsPerSquareCentimeter should be(GramsPerSquareCentimeter(d))
   }
 
   it should "provide Numeric support" in {


### PR DESCRIPTION
We are using Squants at Cibo Technologies for units in agricultural applications.  We needed some new AreaDensity types, but the conversions in the base AreaDensity assumed that the type was KilogramsPerSquareMeters.

I've added two new AreaDensity units and fixed the base class so it works with multiple units.