### PR TITLE
Spectral irradiance

### DIFF
--- a/shared/src/main/scala/squants/radio/Irradiance.scala
+++ b/shared/src/main/scala/squants/radio/Irradiance.scala
@@ -9,8 +9,8 @@
 package squants.radio
 
 import squants._
-import squants.energy.Watts
-import squants.space.SquareMeters
+import squants.energy.{ErgsPerSecond, Watts}
+import squants.space.{SquareCentimeters, SquareMeters}
 
 /**
  * @author  garyKeorkunian
@@ -26,6 +26,7 @@ final class Irradiance private (val value: Double, val unit: IrradianceUnit)
   def *(that: Area): Power = Watts(toWattsPerSquareMeter * that.toSquareMeters)
 
   def toWattsPerSquareMeter = to(WattsPerSquareMeter)
+  def toErgsPerSecondPerSquareCentimeter = to(ErgsPerSecondPerSquareCentimeter)
 }
 
 object Irradiance extends Dimension[Irradiance] {
@@ -34,10 +35,10 @@ object Irradiance extends Dimension[Irradiance] {
   def name = "Irradiance"
   def primaryUnit = WattsPerSquareMeter
   def siUnit = WattsPerSquareMeter
-  def units = Set(WattsPerSquareMeter)
+  def units = Set(WattsPerSquareMeter, ErgsPerSecondPerSquareCentimeter)
 }
 
-trait IrradianceUnit extends UnitOfMeasure[Irradiance] {
+trait IrradianceUnit extends UnitOfMeasure[Irradiance] with UnitConverter {
   def apply[A](n: A)(implicit num: Numeric[A]) = Irradiance(n, this)
 }
 
@@ -45,11 +46,18 @@ object WattsPerSquareMeter extends IrradianceUnit with PrimaryUnit with SiUnit {
   val symbol = Watts.symbol + "/" + SquareMeters.symbol
 }
 
+object ErgsPerSecondPerSquareCentimeter extends IrradianceUnit {
+  val conversionFactor = ErgsPerSecond.conversionFactor / SquareCentimeters.conversionFactor
+  val symbol = ErgsPerSecond.symbol + "/" + SquareCentimeters.symbol
+}
+
 object IrradianceConversions {
   lazy val wattPerSquareMeter = WattsPerSquareMeter(1)
+  lazy val ergsPerSecondPerSquareCentimeter = ErgsPerSecondPerSquareCentimeter(1)
 
   implicit class IrradianceConversions[A](n: A)(implicit num: Numeric[A]) {
     def wattsPerSquareMeter = WattsPerSquareMeter(n)
+    def ergsPerSecondPerSquareCentimeter = ErgsPerSecondPerSquareCentimeter(n)
   }
 
   implicit object IrradianceNumeric extends AbstractQuantityNumeric[Irradiance](Irradiance.primaryUnit)

--- a/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
+++ b/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
@@ -1,0 +1,78 @@
+/*                                                                      *\
+** Squants                                                              **
+**                                                                      **
+** Scala Quantities and Units of Measure Library and DSL                **
+** (c) 2013-2015, Gary Keorkunian                                       **
+**                                                                      **
+\*                                                                      */
+
+package squants.radio
+
+import squants._
+import squants.energy.{ErgsPerSecond, Watts}
+import squants.space._
+
+/**
+ * @author  florianNussberger
+ * @since   0.6
+ *
+ * @param value Double
+ */
+final class SpectralIrradiance private (val value: Double, val unit: SpectralIrradianceUnit)
+    extends Quantity[SpectralIrradiance] {
+
+  def dimension = SpectralIrradiance
+
+//  def *(that: Area): Power = Watts(toWattsPerSquareMeter * that.toSquareMeters)
+//  def /(that: Power): Area = SquareMeters(toWattsPerSquareMeter / that.toWatts)
+
+  def toWattsPerCubicMeter = to(WattsPerCubicMeter)
+  def toWattsPerSquareMeterPerNanometer = to(WattsPerSquareMeterPerNanometer)
+  def toWattsPerSquareMeterPerMicron = to(WattsPerSquareMeterPerMicron)
+  def toErgsPerSecondPerSquareCentimeterPerAngstrom = to(ErgsPerSecondPerSquareCentimeterPerAngstrom)
+}
+
+object SpectralIrradiance extends Dimension[SpectralIrradiance] {
+  private[radio] def apply[A](n: A, unit: SpectralIrradianceUnit)(implicit num: Numeric[A]) = new SpectralIrradiance(num.toDouble(n), unit)
+  def apply = parse _
+  def name = "SpectralIrradiance"
+  def primaryUnit = WattsPerCubicMeter
+  def siUnit = WattsPerCubicMeter
+  def units = Set(WattsPerCubicMeter, WattsPerSquareMeterPerMicron, WattsPerSquareMeterPerNanometer, ErgsPerSecondPerSquareCentimeterPerAngstrom)
+}
+
+trait SpectralIrradianceUnit extends UnitOfMeasure[SpectralIrradiance] with UnitConverter {
+  def apply[A](n: A)(implicit num: Numeric[A]) = SpectralIrradiance(n, this)
+}
+
+object WattsPerCubicMeter extends SpectralIrradianceUnit with PrimaryUnit with SiUnit {
+  val symbol = Watts.symbol + "/" + CubicMeters.symbol
+}
+
+object WattsPerSquareMeterPerNanometer extends SpectralIrradianceUnit {
+  val conversionFactor = 1 / MetricSystem.Nano
+  val symbol = Watts.symbol + "/" + SquareMeters.symbol + "/" + Nanometers.symbol
+ }
+
+object WattsPerSquareMeterPerMicron extends SpectralIrradianceUnit {
+  val conversionFactor = 1 / MetricSystem.Micro
+  val symbol = Watts.symbol + "/" + SquareMeters.symbol + "/" + Microns.symbol
+}
+
+object ErgsPerSecondPerSquareCentimeterPerAngstrom extends SpectralIrradianceUnit {
+  val conversionFactor = ErgsPerSecond.conversionFactor / SquareCentimeters.conversionFactor / Angstroms.conversionFactor
+  val symbol = ErgsPerSecond.symbol + "/" + SquareCentimeters.symbol + "/" + Angstroms.symbol
+}
+
+object SpectralIrradianceConversions {
+  lazy val wattPerCubicMeter = WattsPerCubicMeter(1)
+
+  implicit class SpectralIrradianceConversions[A](n: A)(implicit num: Numeric[A]) {
+    def wattsPerCubicMeter = WattsPerCubicMeter(n)
+    def wattsPerSquareMeterPerNanometer = WattsPerSquareMeterPerNanometer(n)
+    def wattsPerSquareMeterPerMicron = WattsPerSquareMeterPerMicron(n)
+    def ergsPerSecondPerSquareCentimeterPerAngstrom = ErgsPerSecondPerSquareCentimeterPerAngstrom(n)
+  }
+
+  implicit object IrradianceNumeric extends AbstractQuantityNumeric[SpectralIrradiance](SpectralIrradiance.primaryUnit)
+}

--- a/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
+++ b/shared/src/main/scala/squants/radio/SpectralIrradiance.scala
@@ -23,9 +23,6 @@ final class SpectralIrradiance private (val value: Double, val unit: SpectralIrr
 
   def dimension = SpectralIrradiance
 
-//  def *(that: Area): Power = Watts(toWattsPerSquareMeter * that.toSquareMeters)
-//  def /(that: Power): Area = SquareMeters(toWattsPerSquareMeter / that.toWatts)
-
   def toWattsPerCubicMeter = to(WattsPerCubicMeter)
   def toWattsPerSquareMeterPerNanometer = to(WattsPerSquareMeterPerNanometer)
   def toWattsPerSquareMeterPerMicron = to(WattsPerSquareMeterPerMicron)
@@ -66,6 +63,9 @@ object ErgsPerSecondPerSquareCentimeterPerAngstrom extends SpectralIrradianceUni
 
 object SpectralIrradianceConversions {
   lazy val wattPerCubicMeter = WattsPerCubicMeter(1)
+  lazy val wattPerSquareMeterPerNanometer = WattsPerSquareMeterPerNanometer(1)
+  lazy val wattPerSquareMeterPerMicron = WattsPerSquareMeterPerMicron(1)
+  lazy val ergPerSecondPerSquareCentimeterPerAngstrom = ErgsPerSecondPerSquareCentimeterPerAngstrom(1)
 
   implicit class SpectralIrradianceConversions[A](n: A)(implicit num: Numeric[A]) {
     def wattsPerCubicMeter = WattsPerCubicMeter(n)
@@ -74,5 +74,5 @@ object SpectralIrradianceConversions {
     def ergsPerSecondPerSquareCentimeterPerAngstrom = ErgsPerSecondPerSquareCentimeterPerAngstrom(n)
   }
 
-  implicit object IrradianceNumeric extends AbstractQuantityNumeric[SpectralIrradiance](SpectralIrradiance.primaryUnit)
+  implicit object SpectralIrradianceNumeric extends AbstractQuantityNumeric[SpectralIrradiance](SpectralIrradiance.primaryUnit)
 }

--- a/shared/src/test/scala/squants/radio/IrradianceSpec.scala
+++ b/shared/src/test/scala/squants/radio/IrradianceSpec.scala
@@ -8,10 +8,10 @@
 
 package squants.radio
 
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
 import squants.QuantityParseException
 import squants.energy.Watts
-import squants.space.SquareMeters
+import squants.space.{SquareCentimeters, SquareMeters}
 
 import scala.language.postfixOps
 
@@ -26,10 +26,12 @@ class IrradianceSpec extends FlatSpec with Matchers {
 
   it should "create values using UOM factories" in {
     WattsPerSquareMeter(1).toWattsPerSquareMeter should be(1)
+    ErgsPerSecondPerSquareCentimeter(1).toErgsPerSecondPerSquareCentimeter should be(1)
   }
 
   it should "create values from properly formatted Strings" in {
     Irradiance("10.22 W/m²").get should be(WattsPerSquareMeter(10.22))
+    Irradiance("5 erg/s/cm²").get should be(ErgsPerSecondPerSquareCentimeter(5))
     Irradiance("10.22 zz").failed.get should be(QuantityParseException("Unable to parse Irradiance", "10.22 zz"))
     Irradiance("zz W/m²").failed.get should be(QuantityParseException("Unable to parse Irradiance", "zz W/m²"))
   }
@@ -37,14 +39,21 @@ class IrradianceSpec extends FlatSpec with Matchers {
   it should "properly convert to all supported Units of Measure" in {
     val x = WattsPerSquareMeter(1)
     x.toWattsPerSquareMeter should be(1)
+    x.toErgsPerSecondPerSquareCentimeter should be(1000.0 +- 1e-5)
+
+    val y = ErgsPerSecondPerSquareCentimeter(1)
+    y.toErgsPerSecondPerSquareCentimeter should be(1)
+    y.toWattsPerSquareMeter should be(0.001 +- 1e-4)
   }
 
   it should "return properly formatted strings for all supported Units of Measure" in {
     WattsPerSquareMeter(1).toString should be("1.0 W/m²")
+    ErgsPerSecondPerSquareCentimeter(1).toString should be("1.0 erg/s/cm²")
   }
 
   it should "return Power when multiplied by Area" in {
     WattsPerSquareMeter(1) * SquareMeters(1) should be(Watts(1))
+    (ErgsPerSecondPerSquareCentimeter(1) * SquareCentimeters(1)).toErgsPerSecond should be(1.0 +- 1e-5)
   }
 
   behavior of "IrradianceConversions"
@@ -53,6 +62,7 @@ class IrradianceSpec extends FlatSpec with Matchers {
     import IrradianceConversions._
 
     wattPerSquareMeter should be(WattsPerSquareMeter(1))
+    ergsPerSecondPerSquareCentimeter should be(ErgsPerSecondPerSquareCentimeter(1))
   }
 
   it should "provide implicit conversion from Double" in {
@@ -60,6 +70,7 @@ class IrradianceSpec extends FlatSpec with Matchers {
 
     val d = 10.22d
     d.wattsPerSquareMeter should be(WattsPerSquareMeter(d))
+    d.ergsPerSecondPerSquareCentimeter should be(ErgsPerSecondPerSquareCentimeter(d))
   }
 
   it should "provide Numeric support" in {
@@ -67,5 +78,8 @@ class IrradianceSpec extends FlatSpec with Matchers {
 
     val irrs = List(WattsPerSquareMeter(10), WattsPerSquareMeter(100))
     irrs.sum should be(WattsPerSquareMeter(110))
+
+    val irrsErg = List(ErgsPerSecondPerSquareCentimeter(10), ErgsPerSecondPerSquareCentimeter(100))
+    irrsErg.sum should be(ErgsPerSecondPerSquareCentimeter(110))
   }
 }

--- a/shared/src/test/scala/squants/radio/SpectralIrradianceSpec.scala
+++ b/shared/src/test/scala/squants/radio/SpectralIrradianceSpec.scala
@@ -1,0 +1,106 @@
+/*                                                                      *\
+** Squants                                                              **
+**                                                                      **
+** Scala Quantities and Units of Measure Library and DSL                **
+** (c) 2013-2015, Gary Keorkunian                                       **
+**                                                                      **
+\*                                                                      */
+
+package squants.radio
+
+import org.scalatest.{FlatSpec, Matchers}
+import squants.QuantityParseException
+
+import scala.language.postfixOps
+
+/**
+ * @author  cquiroz@gemini.edu
+ * @since   0.6.1
+ *
+ */
+class SpectralIrradianceSpec extends FlatSpec with Matchers {
+
+  behavior of "SpectralIrradiance and its Units of Measure"
+
+  it should "create values using UOM factories" in {
+    WattsPerCubicMeter(1).toWattsPerCubicMeter should be(1)
+    WattsPerSquareMeterPerNanometer(1).toWattsPerSquareMeterPerNanometer should be(1)
+    WattsPerSquareMeterPerMicron(1).toWattsPerSquareMeterPerMicron should be(1)
+    ErgsPerSecondPerSquareCentimeterPerAngstrom(1).toErgsPerSecondPerSquareCentimeterPerAngstrom should be(1)
+  }
+
+  it should "create values from properly formatted Strings" in {
+    SpectralIrradiance("10.22 W/m³").get should be(WattsPerCubicMeter(10.22))
+    SpectralIrradiance("10.22 W/m²/nm").get should be(WattsPerSquareMeterPerNanometer(10.22))
+    SpectralIrradiance("10.22 W/m²/µm").get should be(WattsPerSquareMeterPerMicron(10.22))
+    SpectralIrradiance("10.22 erg/s/cm²/Å").get should be(ErgsPerSecondPerSquareCentimeterPerAngstrom(10.22))
+    SpectralIrradiance("10.22 zz").failed.get should be(QuantityParseException("Unable to parse SpectralIrradiance", "10.22 zz"))
+    SpectralIrradiance("zz W/m²").failed.get should be(QuantityParseException("Unable to parse SpectralIrradiance", "zz W/m²"))
+  }
+
+  it should "properly convert to all supported Units of Measure" in {
+    val x = WattsPerCubicMeter(1)
+    x.toWattsPerSquareMeterPerNanometer should be(1.0e-9 +- 1.0e-12)
+    x.toWattsPerSquareMeterPerMicron should be(1.0e-6 +-1.0e-12)
+    x.toErgsPerSecondPerSquareCentimeterPerAngstrom should be(1.0e-7 +-1.0e-12)
+
+    val y = WattsPerSquareMeterPerNanometer(1)
+    y.toWattsPerCubicMeter should be(1.0e+9 +- 1.0e-5)
+    y.toWattsPerSquareMeterPerMicron should be(1.0e+3 +- 1.0e-5)
+    y.toErgsPerSecondPerSquareCentimeterPerAngstrom should be(100.0 +- 1.0e-5)
+
+    val z = WattsPerSquareMeterPerMicron(1)
+    z.toWattsPerCubicMeter should be(1.0e+6 +- 1.0e-5)
+    z.toWattsPerSquareMeterPerNanometer should be(1.0e-3 +- 1.0e-5)
+    z.toErgsPerSecondPerSquareCentimeterPerAngstrom should be(1.0e-1 +- 1.0e-5)
+
+    val u = ErgsPerSecondPerSquareCentimeterPerAngstrom(1)
+    u.toWattsPerCubicMeter should be(1.0e+7 +- 1.0e-5)
+    u.toWattsPerSquareMeterPerNanometer should be(1.0e-2 +- 1.0e-5)
+    u.toWattsPerSquareMeterPerMicron should be(10.0 +- 1.0e-5)
+  }
+
+  it should "return properly formatted strings for all supported Units of Measure" in {
+    WattsPerCubicMeter(1).toString should be("1.0 W/m³")
+    WattsPerSquareMeterPerNanometer(1).toString should be("1.0 W/m²/nm")
+    WattsPerSquareMeterPerMicron(1).toString should be("1.0 W/m²/µm")
+    ErgsPerSecondPerSquareCentimeterPerAngstrom(1).toString should be("1.0 erg/s/cm²/Å")
+  }
+
+  behavior of "SpectralIrradianceConversions"
+
+  it should "provide aliases for single unit values" in {
+    import SpectralIrradianceConversions._
+
+    wattPerCubicMeter should be(WattsPerCubicMeter(1))
+    wattPerSquareMeterPerNanometer should be(WattsPerSquareMeterPerNanometer(1))
+    wattPerSquareMeterPerMicron should be(WattsPerSquareMeterPerMicron(1))
+    ergPerSecondPerSquareCentimeterPerAngstrom should be(ErgsPerSecondPerSquareCentimeterPerAngstrom(1))
+  }
+
+  it should "provide implicit conversion from Double" in {
+    import SpectralIrradianceConversions._
+
+    val d = 10.22d
+    d.wattsPerCubicMeter should be(WattsPerCubicMeter(d))
+    d.wattsPerSquareMeterPerMicron should be(WattsPerSquareMeterPerMicron(d))
+    d.wattsPerSquareMeterPerNanometer should be(WattsPerSquareMeterPerNanometer(d))
+    d.ergsPerSecondPerSquareCentimeterPerAngstrom should be(ErgsPerSecondPerSquareCentimeterPerAngstrom(d))
+  }
+
+  it should "provide Numeric support" in {
+    import SpectralIrradianceConversions.SpectralIrradianceNumeric
+
+    val irrsWPCM = List(WattsPerCubicMeter(10), WattsPerCubicMeter(100))
+    irrsWPCM.sum should be(WattsPerCubicMeter(110))
+
+    val irrsWPSMPM = List(WattsPerSquareMeterPerMicron(10), WattsPerSquareMeterPerMicron(100))
+    irrsWPSMPM.sum should be(WattsPerSquareMeterPerMicron(110))
+
+    val irrsWPSMPN = List(WattsPerSquareMeterPerNanometer(10), WattsPerSquareMeterPerNanometer(100))
+    irrsWPSMPN.sum should be(WattsPerSquareMeterPerNanometer(110))
+
+    val irrsEPSCA = List(ErgsPerSecondPerSquareCentimeterPerAngstrom(10), ErgsPerSecondPerSquareCentimeterPerAngstrom(100))
+    irrsEPSCA.sum should be(ErgsPerSecondPerSquareCentimeterPerAngstrom(110))
+  }
+}


### PR DESCRIPTION
This PR adds the quantity `SpectralIrradiance` and their related units. Unit tests are provided for the quantity and units

[SpectralIrradiance](https://en.wikipedia.org/wiki/Irradiance#Spectral_irradiance) is used in astronomy for a variety of measurements