### PR TITLE
OSGi support

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,7 +1,8 @@
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import sbt.Keys._
 import sbt._
-
+import com.typesafe.sbt.osgi.SbtOsgi
+import com.typesafe.sbt.osgi.SbtOsgi.autoImport._
 
 object Versions {
   val Squants = "0.6.1-SNAPSHOT"
@@ -43,7 +44,11 @@ object Project {
         Resolvers.sonatypeNexusSnapshots,
         Resolvers.sonatypeNexusReleases,
         Resolvers.sonatypeNexusStaging
-    )
+    ),
+
+    OsgiKeys.exportPackage := Seq("squants.*"),
+
+    OsgiKeys.privatePackage := Seq() // No private packages
   )
 }
 
@@ -222,10 +227,13 @@ object SquantsBuild extends Build {
     .crossType(CrossType.Full)
     .in(file("."))
     .settings(defaultSettings: _*)
+    .jvmSettings(
+      osgiSettings: _*
+    )
     .jsSettings(
       excludeFilter in Test := "*Serializer.scala" || "*SerializerSpec.scala"
     )
 
- 	lazy val squantsJVM = squants.jvm
+ 	lazy val squantsJVM = squants.jvm.enablePlugins(SbtOsgi)
  	lazy val squantsJS = squants.js
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.5")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")


### PR DESCRIPTION
I'd like to get OSGi support on squants, which would let us use the binaries as published. OSGi support is essentially adding some headers to the Manifest, and this PR will do that using sbt-osgi.

Hopefully this could be included in the next release