### PR TITLE
Add `money / price` in place of `price * money`

### DIFF
--- a/shared/src/main/scala/squants/market/Money.scala
+++ b/shared/src/main/scala/squants/market/Money.scala
@@ -180,6 +180,14 @@ final class Money private (val amount: BigDecimal)(val currency: Currency)
   def /[A <: Quantity[A]](that: A): Price[A] = Price(this, that)
 
   /**
+   * Divide this money by a Price and return Quantity
+   * @param that Price
+   * @tparam A Quantity Type
+   * @return A
+   */
+  def /[A <: Quantity[A]](that: Price[A]): A = that.quantity * (this / that.money).toDouble
+
+  /**
    * Override for Quantity.divide to only work on Moneys of like Currency
    * Cross currency subtractions should use moneyMinus
    *

--- a/shared/src/main/scala/squants/market/Price.scala
+++ b/shared/src/main/scala/squants/market/Price.scala
@@ -60,7 +60,8 @@ case class Price[A <: Quantity[A]](money: Money, quantity: A) extends Ratio[Mone
    * @param that Money
    * @return
    */
-  def *(that: Money): A = convertToCounter(that)
+  @deprecated("Use `money / price` instead", "0.6.3")
+  def *(that: Money): A = that / this
 
   override def toString = money.toString + "/" + quantity.toString
 

--- a/shared/src/test/scala/squants/market/MoneySpec.scala
+++ b/shared/src/test/scala/squants/market/MoneySpec.scala
@@ -8,10 +8,13 @@
 
 package squants.market
 
-import org.scalatest.{ Matchers, FlatSpec }
-import scala.language.postfixOps
-import squants.mass.Kilograms
+import org.scalatest.{ FlatSpec, Matchers }
 import squants.QuantityParseException
+import squants.mass.Kilograms
+import squants.space.Meters
+import squants.time.Hours
+
+import scala.language.postfixOps
 
 /**
  * @author  garyKeorkunian
@@ -419,5 +422,17 @@ class MoneySpec extends FlatSpec with Matchers {
 
     val ms2 = List(USD(100), CAD(100), JPY(100))
     ms2.sum should be(USD(111))
+  }
+
+  it should "return price when dividing by quantity" in {
+    val m = USD(100)
+    val t = Hours(1)
+
+    (m / t) should be(Price(USD(100), Hours(1)))
+  }
+
+  it should "return quantity when dividing by price" in {
+    val p = Price(Money(10, "USD"), Meters(1))
+    Money(40, "USD") / p should be(Meters(4))
   }
 }


### PR DESCRIPTION
To get a Quantity, the operation should be `money / price`, not
`price * money`.

E.g. when money is in USD and price is in USD/hour, the expression
`price * money` is supposed to have a dimension of `USD^2 / hour`, not
`hour`. To get the dimension `hour`, the expression `money / price`
needs to be used.
